### PR TITLE
docs: cross-reference Poirot2 for representation-layer diagnostics

### DIFF
--- a/AGENT-DEBUGGING.md
+++ b/AGENT-DEBUGGING.md
@@ -376,6 +376,27 @@ Use undo as many times as needed to get back to a known good state. Then rebuild
 explicit verification steps — check sketch constraints, verify sketch is fully
 constrained before closing, check solid validity after each boolean.
 
+**Step 6 — If the result still looks wrong with no error to chase, consider
+representation-layer failures:**
+
+There is a class of FreeCAD bugs where the **model is semantically correct
+but the underlying topology has accumulated drift** that breaks OCCT
+Boolean operations silently — `BRepAlgoAPI_Fuse` returns one operand
+unchanged, `Part::MultiFuse` produces an incomplete shape, no error or
+warning anywhere. The steps above (`view_control` / `list_objects` /
+`measurement_operations` / `get_debug_logs`) don't surface these because
+the symptom is on the OCCT side, not the FreeCAD side.
+
+For diagnosing this class of failure (silent Boolean drops, edge-coincident
+fuse failures, accumulated-history drift, deprecated-property warnings the
+user missed, orphaned-feature parametric-link breakage), see
+[Poirot2](https://github.com/blwfish/Poirot2) — a diagnostic library +
+assistant playbook that runs inside FreeCAD via this MCP bridge and adds
+representation-layer probes (`check_boolean_health` cross-checks
+`BRepAlgoAPI` against `BOPAlgo_Builder`; `find_recent_orphans` sweeps for
+null required references; etc.). Its `AGENT-OPERATION.md` is the
+companion playbook for this kind of diagnosis.
+
 ---
 
 ## 5. Sketch or Constraint Failure


### PR DESCRIPTION
## Summary

Add a new Step 6 to `AGENT-DEBUGGING.md` §4 ("Operation Succeeded But Result Looks Wrong"), pointing readers at [Poirot2](https://github.com/blwfish/Poirot2) for the class of failures this MCP's standard diagnostic toolkit doesn't directly surface:

- Silent OCCT Boolean operand drops (`BRepAlgoAPI_Fuse` returns one operand unchanged)
- Edge-coincident fuse failures
- Accumulated-history drift breaking Boolean operations
- Orphaned-feature parametric-link breakage that's only visible in Report View

Poirot2 is a Python library + assistant playbook that runs *inside* FreeCAD via this MCP bridge — it doesn't replace `view_control` / `list_objects` / `measurement_operations` / `get_debug_logs`; it adds representation-layer probes (like `check_boolean_health`, which cross-checks `BRepAlgoAPI` against `BOPAlgo_Builder`) on top.

## Why here

The motivating case was a year-long ghost-hunt for a silent `BRepAlgoAPI_Fuse` failure on a lens-hood model. The standard freecad-mcp toolkit didn't surface it (no exception, no Report View entry, valid shape) because the failure is on the OCCT side. AGENT-DEBUGGING §4 is exactly the right surface for "looks right, isn't" cases — adding the pointer there means any agent following this playbook will know to reach for Poirot2 when the existing steps don't yield.

## Scope

Documentation only. No behavior change. 21 lines added to one file.

## Test plan

- [x] Markdown renders correctly (verified locally)
- [ ] No links broken (only one new link: `https://github.com/blwfish/Poirot2`)