### PR TITLE
feat: multi-instance discovery + UUID registry (PR-A of multi-GUI series)

### DIFF
--- a/AICopilot/InitGui.py
+++ b/AICopilot/InitGui.py
@@ -55,6 +55,26 @@ else:
                 FreeCAD.Console.PrintError(f"Socket server error: {e}\n")
                 return False
 
+            # Write discovery file so the bridge (and tools) can find this instance.
+            try:
+                import instance_registry
+                fc_version = None
+                try:
+                    fc_version = ".".join(str(p) for p in FreeCAD.Version()[:3])
+                except Exception:
+                    pass
+                instance_registry.write_discovery(
+                    self.socket_server.instance_uuid,
+                    self.socket_server.socket_path,
+                    gui=True,
+                    label=os.environ.get("FREECAD_MCP_LABEL"),
+                    freecad_version=fc_version,
+                    freecad_binary=sys.executable,
+                )
+                self.instance_uuid = self.socket_server.instance_uuid
+            except Exception as e:
+                FreeCAD.Console.PrintWarning(f"Discovery file not written: {e}\n")
+
             self.is_running = True
             FreeCAD.__ai_global_service = self
             FreeCAD.Console.PrintMessage("AI Copilot Service running - available from all workbenches\n")
@@ -72,6 +92,15 @@ else:
                 self.socket_server = None
 
             self.is_running = False
+
+            # Remove discovery file before clearing FreeCAD attrs.
+            uid = getattr(self, "instance_uuid", None)
+            if uid:
+                try:
+                    import instance_registry
+                    instance_registry.remove_discovery(uid)
+                except Exception:
+                    pass
 
             for attr in ('__ai_socket_server', '__ai_global_service'):
                 if hasattr(FreeCAD, attr):

--- a/AICopilot/crash_watcher.py
+++ b/AICopilot/crash_watcher.py
@@ -17,13 +17,15 @@ Usage (called by freecad_mcp_handler.py):
 The file is intentionally NOT cleared on crash — that's the whole point.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 import json
 import os
 import time
 
-LAST_OP_FILE = "/tmp/freecad_mcp_last_op.json"
+# Per-instance file: each FreeCAD process writes to its own path so that
+# multiple concurrent instances don't clobber one another's crash context.
+LAST_OP_FILE = f"/tmp/freecad_mcp_last_op_{os.getpid()}.json"
 _MAX_ARG_BYTES = 1500   # truncate large args (e.g. long Python scripts)
 
 

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -45,8 +45,10 @@ MAX_ASYNC_JOBS = 50
 # Completed jobs older than this (seconds) are automatically cleaned up
 ASYNC_JOB_TTL = 600
 
-# Configurable socket path/port via environment variables
-SOCKET_PATH = os.environ.get("FREECAD_MCP_SOCKET", "/tmp/freecad_mcp.sock")
+# Configurable socket path/port via environment variables.
+# SOCKET_PATH is None when the env var is unset; start_server() then
+# generates /tmp/freecad_mcp_<uuid>.sock from instance_registry.
+SOCKET_PATH = os.environ.get("FREECAD_MCP_SOCKET") or None
 WINDOWS_HOST = "localhost"
 WINDOWS_PORT = int(os.environ.get("FREECAD_MCP_PORT", "23456"))
 
@@ -326,6 +328,32 @@ class FreeCADSocketServer:
     def start_server(self):
         """Start the socket server."""
         try:
+            # Always generate a UUID for this instance — used for discovery file
+            # whether the socket path was env-supplied or auto-generated.
+            try:
+                from instance_registry import generate_uuid, is_socket_alive, default_socket_path
+            except ImportError:
+                # Fallback shim: registry module missing (shouldn't happen in shipped
+                # builds, but keep the server functional in dev scratchpads).
+                import uuid as _uuid
+                def generate_uuid():
+                    return _uuid.uuid4().hex[:12]
+                def default_socket_path(u):
+                    return f"/tmp/freecad_mcp_{u}.sock"
+                def is_socket_alive(p, timeout=0.5):
+                    if not os.path.exists(p):
+                        return False
+                    try:
+                        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                        s.settimeout(timeout)
+                        s.connect(p)
+                        s.close()
+                        return True
+                    except OSError:
+                        return False
+
+            self.instance_uuid = generate_uuid()
+
             if IS_WINDOWS:
                 self.socket_path = None
                 self.server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -335,13 +363,31 @@ class FreeCADSocketServer:
                     f"Socket server started on {WINDOWS_HOST}:{WINDOWS_PORT} (Windows TCP)\n"
                 )
             else:
-                self.socket_path = SOCKET_PATH
+                # Resolve the socket path:
+                #   FREECAD_MCP_SOCKET wins if set; otherwise UUID-suffixed default.
+                if SOCKET_PATH:
+                    self.socket_path = SOCKET_PATH
+                else:
+                    self.socket_path = default_socket_path(self.instance_uuid)
+
+                # Probe-before-unlink: never stomp a live peer's socket.
                 if os.path.exists(self.socket_path):
+                    if is_socket_alive(self.socket_path):
+                        FreeCAD.Console.PrintError(
+                            f"Socket {self.socket_path} is already in use by another live "
+                            "FreeCAD instance. Refusing to start. Set FREECAD_MCP_SOCKET "
+                            "to a unique path, or stop the other instance first.\n"
+                        )
+                        return False
+                    # Stale socket from a prior crash — safe to remove.
                     os.remove(self.socket_path)
+
                 self.server_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 self.server_socket.bind(self.socket_path)
                 os.chmod(self.socket_path, 0o600)
-                FreeCAD.Console.PrintMessage(f"Socket server started on {self.socket_path}\n")
+                FreeCAD.Console.PrintMessage(
+                    f"Socket server started on {self.socket_path} (uuid={self.instance_uuid})\n"
+                )
 
             self.server_socket.listen(5)
             self.running = True

--- a/AICopilot/headless_server.py
+++ b/AICopilot/headless_server.py
@@ -88,10 +88,15 @@ except ImportError:
 # Start the socket server
 # ---------------------------------------------------------------------------
 def main():
-    active_socket = os.environ.get("FREECAD_MCP_SOCKET", "/tmp/freecad_mcp.sock")
-    FreeCAD.Console.PrintMessage(
-        f"[Headless MCP] Starting socket server on {active_socket}\n"
-    )
+    requested_socket = os.environ.get("FREECAD_MCP_SOCKET")
+    if requested_socket:
+        FreeCAD.Console.PrintMessage(
+            f"[Headless MCP] Starting socket server on {requested_socket}\n"
+        )
+    else:
+        FreeCAD.Console.PrintMessage(
+            "[Headless MCP] Starting socket server (path auto-generated)\n"
+        )
 
     try:
         from freecad_mcp_handler import FreeCADSocketServer
@@ -110,8 +115,30 @@ def main():
     # Expose on FreeCAD module so execute_python code can reach it if needed
     FreeCAD.__ai_socket_server = server
 
+    # Write discovery file (best-effort — never fatal).
+    instance_uuid = None
+    try:
+        import instance_registry
+        fc_version = None
+        try:
+            fc_version = ".".join(str(p) for p in FreeCAD.Version()[:3])
+        except Exception:
+            pass
+        instance_registry.write_discovery(
+            server.instance_uuid,
+            server.socket_path,
+            gui=False,
+            label=os.environ.get("FREECAD_MCP_LABEL"),
+            freecad_version=fc_version,
+            freecad_binary=sys.executable,
+        )
+        instance_uuid = server.instance_uuid
+    except Exception as e:
+        FreeCAD.Console.PrintWarning(f"[Headless MCP] Discovery file not written: {e}\n")
+
     FreeCAD.Console.PrintMessage(
-        f"[Headless MCP] Ready. Listening on {active_socket}\n"
+        f"[Headless MCP] Ready. Listening on {server.socket_path} "
+        f"(uuid={server.instance_uuid})\n"
     )
 
     # ---------------------------------------------------------------------------
@@ -138,6 +165,12 @@ def main():
     finally:
         FreeCAD.Console.PrintMessage("[Headless MCP] Stopping socket server.\n")
         server.stop_server()
+        if instance_uuid:
+            try:
+                import instance_registry
+                instance_registry.remove_discovery(instance_uuid)
+            except Exception:
+                pass
         if hasattr(FreeCAD, "__ai_socket_server"):
             del FreeCAD.__ai_socket_server
 

--- a/AICopilot/instance_registry.py
+++ b/AICopilot/instance_registry.py
@@ -1,0 +1,138 @@
+"""Instance discovery registry for FreeCAD MCP.
+
+Each AICopilot instance (GUI or headless) writes a JSON discovery file at
+startup and removes it at shutdown. The bridge scans this directory to find
+all live FreeCAD instances, regardless of who launched them.
+
+Both AICopilot side (this module) and bridge side (freecad_mcp_server.py)
+must agree on:
+  - DISCOVERY_DIR location
+  - JSON schema (see write_discovery)
+"""
+
+__version__ = "1.0.0"
+
+import json
+import os
+import socket
+import time
+import uuid
+
+DISCOVERY_DIR = os.path.expanduser("~/.cache/freecad-mcp/instances")
+
+
+def ensure_dir() -> str:
+    os.makedirs(DISCOVERY_DIR, mode=0o700, exist_ok=True)
+    return DISCOVERY_DIR
+
+
+def generate_uuid() -> str:
+    """Short hex UUID used as the instance identifier."""
+    return uuid.uuid4().hex[:12]
+
+
+def discovery_path(instance_uuid: str) -> str:
+    return os.path.join(DISCOVERY_DIR, f"{instance_uuid}.json")
+
+
+def default_socket_path(instance_uuid: str) -> str:
+    return f"/tmp/freecad_mcp_{instance_uuid}.sock"
+
+
+def write_discovery(
+    instance_uuid: str,
+    socket_path: str,
+    *,
+    gui: bool,
+    label: str | None = None,
+    freecad_version: str | None = None,
+    freecad_binary: str | None = None,
+) -> str:
+    """Atomically write the discovery file for this instance.
+
+    Returns the absolute path of the written file.
+    """
+    ensure_dir()
+    data = {
+        "uuid": instance_uuid,
+        "pid": os.getpid(),
+        "socket_path": socket_path,
+        "gui": gui,
+        "label": label or instance_uuid,
+        "started_at": time.time(),
+        "freecad_version": freecad_version,
+        "freecad_binary": freecad_binary,
+    }
+    path = discovery_path(instance_uuid)
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(data, f, indent=2)
+    os.replace(tmp, path)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+    return path
+
+
+def remove_discovery(instance_uuid: str) -> None:
+    """Remove this instance's discovery file. Safe to call multiple times."""
+    try:
+        os.unlink(discovery_path(instance_uuid))
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+def is_socket_alive(socket_path: str, timeout: float = 0.5) -> bool:
+    """Return True if a Unix socket at socket_path accepts connections."""
+    if not os.path.exists(socket_path):
+        return False
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect(socket_path)
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+def scan_discovery(prune_stale: bool = True) -> list[dict]:
+    """Return list of live instance discovery records.
+
+    A record is considered live if its socket_path is connectable. If
+    prune_stale is True, records whose sockets cannot be reached are deleted
+    from the discovery directory.
+    """
+    try:
+        entries = os.listdir(DISCOVERY_DIR)
+    except FileNotFoundError:
+        return []
+
+    live = []
+    for name in entries:
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(DISCOVERY_DIR, name)
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            # Corrupt or unreadable — drop it
+            if prune_stale:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            continue
+        sock_path = data.get("socket_path")
+        if sock_path and is_socket_alive(sock_path):
+            live.append(data)
+        elif prune_stale:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+    return live

--- a/freecad_crash_report.py
+++ b/freecad_crash_report.py
@@ -56,7 +56,7 @@ from collections import deque
 from pathlib import Path
 from typing import Optional
 
-LAST_OP_FILE = "/tmp/freecad_mcp_last_op.json"
+LAST_OP_FILE_GLOB = "/tmp/freecad_mcp_last_op_*.json"  # per-PID files written by crash_watcher
 OPLOG_FILE   = "/tmp/freecad_mcp_oplog.json"
 MAX_OPLOG    = 10
 
@@ -126,13 +126,29 @@ def _summarize(tool: str, args: dict) -> str:
 # Crash diagnosis helpers
 # ─────────────────────────────────────────────────────────────────────────────
 
-def _read_last_op() -> Optional[dict]:
-    """Read what FreeCAD was executing (written by crash_watcher inside FC)."""
-    try:
-        with open(LAST_OP_FILE) as f:
-            return json.load(f)
-    except Exception:
-        return None
+def _read_last_op(pid: Optional[int] = None) -> Optional[dict]:
+    """Read what FreeCAD was executing (written by crash_watcher inside FC).
+
+    If pid is given, prefer the PID-specific file. Otherwise (or if that file
+    is missing), fall back to the most-recently-modified per-PID file.
+    """
+    candidates = []
+    if pid is not None:
+        candidates.append(f"/tmp/freecad_mcp_last_op_{pid}.json")
+    # Fallback: glob all per-PID files, newest first.
+    all_per_pid = glob.glob(LAST_OP_FILE_GLOB)
+    all_per_pid.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    for p in all_per_pid:
+        if p not in candidates:
+            candidates.append(p)
+
+    for path in candidates:
+        try:
+            with open(path) as f:
+                return json.load(f)
+        except Exception:
+            continue
+    return None
 
 
 def _find_macos_crash_report(max_age_s: int = 180) -> Optional[str]:
@@ -329,10 +345,11 @@ def clear_recovery_files(dry_run: bool = False) -> list:
 
 def diagnose(
     *,
-    socket_path: str = "/tmp/freecad_mcp.sock",
+    socket_path: Optional[str] = None,
     proc=None,              # subprocess.Popen for headless instances
     op_log: Optional[OpLog] = None,
     error: Optional[Exception] = None,
+    pid: Optional[int] = None,
 ) -> str:
     """Return a human-readable markdown crash report.
 
@@ -357,7 +374,7 @@ def diagnose(
                 parts.append(f"  - ✓ `{op['tool']}`")
 
     # ── 2. What was FreeCAD executing? (written by crash_watcher inside FC) ──
-    last_op = _read_last_op()
+    last_op = _read_last_op(pid=pid)
     if last_op:
         age  = time.time() - last_op.get("started_at", time.time())
         tool = last_op.get("tool", "?")

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -21,30 +21,92 @@ from typing import Any
 # Mutable bridge state — socket target + spawned instance registry
 # =============================================================================
 
+DISCOVERY_DIR = os.path.expanduser("~/.cache/freecad-mcp/instances")
+
+
+def _socket_alive(sock_path: str, timeout: float = 0.5) -> bool:
+    """Return True if a Unix socket at sock_path accepts connections."""
+    if not sock_path or not os.path.exists(sock_path):
+        return False
+    try:
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect(sock_path)
+        s.close()
+        return True
+    except OSError:
+        return False
+
+
+def _scan_discovery(prune_stale: bool = True) -> list[dict]:
+    """Read ~/.cache/freecad-mcp/instances/*.json, return live records.
+
+    On Windows this is a no-op (returns []); GUI discovery on Windows is TCP
+    based and uses _ctx.socket_path directly.
+    """
+    if platform.system() == "Windows":
+        return []
+    try:
+        entries = os.listdir(DISCOVERY_DIR)
+    except FileNotFoundError:
+        return []
+
+    live = []
+    for name in entries:
+        if not name.endswith(".json"):
+            continue
+        path = os.path.join(DISCOVERY_DIR, name)
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            if prune_stale:
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+            continue
+        sock_path = data.get("socket_path")
+        if sock_path and _socket_alive(sock_path):
+            live.append(data)
+        elif prune_stale:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+    return live
+
+
 class _BridgeCtx:
     """Holds the active socket path and all spawned instance metadata.
 
     Using a class instance (rather than closure variables) lets nested async
     functions read and write the active target without nonlocal gymnastics.
+
+    `socket_path` starts as None on Unix; the first tool call triggers
+    discovery-based auto-selection. On Windows it's a fixed TCP endpoint
+    (the discovery scheme is Unix-socket-only).
     """
 
     def __init__(self):
         if platform.system() == "Windows":
-            self.socket_path: str = "localhost:23456"
+            self.socket_path: str | None = "localhost:23456"
         else:
-            self.socket_path: str = os.environ.get(
-                "FREECAD_MCP_SOCKET", "/tmp/freecad_mcp.sock"
-            )
-        # socket_path -> {pid, proc, label, headless, started_at}
+            # Honor an explicit env override; otherwise resolve lazily.
+            self.socket_path = os.environ.get("FREECAD_MCP_SOCKET")
+        # socket_path -> {pid, proc, label, headless, started_at, uuid}
         self.instances: dict = {}
 
     @property
     def freecad_available(self) -> bool:
         if platform.system() == "Windows":
             return True
-        return os.path.exists(self.socket_path)
+        if not self.socket_path:
+            return False
+        return _socket_alive(self.socket_path)
 
-    def register(self, sock_path: str, pid: int, proc, label: str, headless: bool = True):
+    def register(self, sock_path: str, pid: int, proc, label: str,
+                 headless: bool = True, instance_uuid: str | None = None):
         self.instances[sock_path] = {
             "socket_path": sock_path,
             "pid": pid,
@@ -52,15 +114,116 @@ class _BridgeCtx:
             "label": label,
             "headless": headless,
             "started_at": time.time(),
+            "uuid": instance_uuid,
         }
 
     def unregister(self, sock_path: str):
         self.instances.pop(sock_path, None)
 
+    def lookup_pid(self, sock_path: str | None) -> int | None:
+        """Find the PID for a socket path, checking managed instances then discovery."""
+        if not sock_path:
+            return None
+        info = self.instances.get(sock_path)
+        if info and info.get("pid"):
+            return info["pid"]
+        for record in _scan_discovery(prune_stale=False):
+            if record.get("socket_path") == sock_path:
+                return record.get("pid")
+        return None
+
+    def resolve_target(self) -> tuple[str | None, str | None]:
+        """Resolve the active socket path. Returns (socket_path, error_or_none).
+
+        Resolution order:
+          1. self.socket_path already set and live → use it.
+          2. self.socket_path set but stale → clear, fall through.
+          3. Scan discovery dir:
+             - 0 live instances → error
+             - 1 live instance  → auto-select, log
+             - 2+ live          → error listing them
+        """
+        if platform.system() == "Windows":
+            return self.socket_path, None
+
+        # 1/2: previously selected target
+        if self.socket_path:
+            if _socket_alive(self.socket_path):
+                return self.socket_path, None
+            # stale — drop it and re-resolve via discovery
+            self.socket_path = None
+
+        # 3: discovery
+        live = _scan_discovery()
+        if not live:
+            return None, (
+                "No live FreeCAD instances found. Start FreeCAD with AICopilot, "
+                "or call spawn_freecad_instance."
+            )
+        if len(live) == 1:
+            self.socket_path = live[0]["socket_path"]
+            return self.socket_path, None
+        # multiple: require explicit selection
+        listing = ", ".join(
+            f"{r.get('label') or r['uuid']} (uuid={r['uuid']}, gui={r.get('gui')})"
+            for r in live
+        )
+        return None, (
+            f"{len(live)} live FreeCAD instances; cannot auto-select. "
+            f"Call select_freecad_instance with one of: {listing}"
+        )
+
     def list_all(self) -> list:
+        """Merge bridge-spawned + discovered instances into a single view.
+
+        If self.socket_path is set but not present in either source (e.g.
+        FREECAD_MCP_SOCKET env override pointing at a hand-launched instance
+        that doesn't write discovery files), a synthetic entry is added so
+        the caller can see the active target.
+        """
         result = []
-        # Current socket (may or may not be a spawned instance)
-        if self.socket_path not in self.instances:
+        seen_paths = set()
+
+        # Bridge-spawned (managed) instances
+        for sp, info in self.instances.items():
+            seen_paths.add(sp)
+            result.append({
+                **{k: v for k, v in info.items() if k != "proc"},
+                "managed": True,
+                "is_current": sp == self.socket_path,
+                "available": _socket_alive(sp) if platform.system() != "Windows" else True,
+            })
+
+        # Discovered (unmanaged) instances
+        if platform.system() != "Windows":
+            for record in _scan_discovery():
+                sp = record.get("socket_path")
+                if sp in seen_paths:
+                    # Already covered by managed listing — annotate with discovery extras
+                    for entry in result:
+                        if entry.get("socket_path") == sp:
+                            entry.setdefault("uuid", record.get("uuid"))
+                            entry.setdefault("gui", record.get("gui"))
+                            entry.setdefault("freecad_version", record.get("freecad_version"))
+                    continue
+                seen_paths.add(sp)
+                result.append({
+                    "socket_path": sp,
+                    "uuid": record.get("uuid"),
+                    "pid": record.get("pid"),
+                    "label": record.get("label"),
+                    "gui": record.get("gui"),
+                    "headless": not record.get("gui", False),
+                    "started_at": record.get("started_at"),
+                    "freecad_version": record.get("freecad_version"),
+                    "freecad_binary": record.get("freecad_binary"),
+                    "managed": False,
+                    "is_current": sp == self.socket_path,
+                    "available": True,  # scan_discovery already pruned dead
+                })
+
+        # Synthetic entry for an explicit env-var target that isn't tracked anywhere
+        if self.socket_path and self.socket_path not in seen_paths:
             result.append({
                 "socket_path": self.socket_path,
                 "label": "default",
@@ -69,13 +232,7 @@ class _BridgeCtx:
                 "is_current": True,
                 "available": self.freecad_available,
             })
-        for sp, info in self.instances.items():
-            result.append({
-                **info,
-                "managed": True,
-                "is_current": sp == self.socket_path,
-                "available": os.path.exists(sp) if platform.system() != "Windows" else True,
-            })
+
         return result
 
 
@@ -192,12 +349,15 @@ _POLL_TIMEOUT_SECS = 120  # 2-minute ceiling; return job_id so caller can cancel
 def _diagnose_crash(error: Exception = None) -> str:
     if _crash_mod is None:
         return f"FreeCAD connection lost: {error}"
-    proc = _ctx.instances.get(_ctx.socket_path, {}).get("proc")
+    info = _ctx.instances.get(_ctx.socket_path, {}) if _ctx.socket_path else {}
+    proc = info.get("proc")
+    pid = info.get("pid") or _ctx.lookup_pid(_ctx.socket_path)
     return _crash_mod.diagnose(
         socket_path=_ctx.socket_path,
         proc=proc,
         op_log=_op_log,
         error=error,
+        pid=pid,
     )
 
 # Initialize debugging infrastructure (optional - works without it)
@@ -255,9 +415,9 @@ async def main():
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.connect(('localhost', 23456))
             else:
-                current_path = _ctx.socket_path
-                if not os.path.exists(current_path):
-                    return json.dumps({"error": "FreeCAD socket not available. Please start FreeCAD with AICopilot installed, or call spawn_freecad_instance."})
+                current_path, err = _ctx.resolve_target()
+                if err:
+                    return json.dumps({"error": err})
                 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
                 sock.connect(current_path)
 
@@ -1444,18 +1604,22 @@ async def main():
                     description=(
                         "Switch the active FreeCAD instance. All subsequent tool calls "
                         "will be routed to this instance. Use list_freecad_instances to "
-                        "see available socket paths / labels."
+                        "see available uuids / labels / socket paths."
                     ),
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "socket_path": {
+                            "uuid": {
                                 "type": "string",
-                                "description": "Socket path of the instance to activate"
+                                "description": "Instance UUID (preferred selector)"
                             },
                             "label": {
                                 "type": "string",
-                                "description": "Label of the instance to activate (alternative to socket_path)"
+                                "description": "Instance label (alternative to uuid)"
+                            },
+                            "socket_path": {
+                                "type": "string",
+                                "description": "Socket path of the instance (alternative to uuid/label)"
                             }
                         }
                     },
@@ -1474,13 +1638,17 @@ async def main():
                     inputSchema={
                         "type": "object",
                         "properties": {
-                            "socket_path": {
+                            "uuid": {
                                 "type": "string",
-                                "description": "Socket path of the instance to stop"
+                                "description": "Instance UUID"
                             },
                             "label": {
                                 "type": "string",
-                                "description": "Label of the instance to stop (alternative to socket_path)"
+                                "description": "Instance label (alternative to uuid)"
+                            },
+                            "socket_path": {
+                                "type": "string",
+                                "description": "Socket path (alternative to uuid/label)"
                             }
                         }
                     },
@@ -1501,12 +1669,14 @@ async def main():
         """Handle tool calls with smart dispatcher routing"""
         
         if name == "check_freecad_connection":
+            # Trigger lazy resolution so available/socket_path reflect discovery.
+            resolved, resolve_err = _ctx.resolve_target()
             available = _ctx.freecad_available
             status = {
                 "freecad_socket_exists": available,
                 "socket_path": _ctx.socket_path,
                 "status": "FreeCAD running with AICopilot" if available
-                         else "FreeCAD not running. Start FreeCAD or call spawn_freecad_instance.",
+                         else (resolve_err or "FreeCAD not running. Start FreeCAD or call spawn_freecad_instance."),
                 "instances": _ctx.list_all(),
             }
             return [types.TextContent(
@@ -1528,7 +1698,7 @@ async def main():
             await asyncio.sleep(3)
             # Poll for new instance (up to 30s)
             for i in range(30):
-                if os.path.exists(_ctx.socket_path):
+                if _ctx.socket_path and os.path.exists(_ctx.socket_path):
                     try:
                         test = await send_to_freecad("test_echo", {"message": "ping"})
                         parsed = json.loads(test)
@@ -1767,12 +1937,38 @@ async def main():
             args = arguments or {}
             target_path = args.get("socket_path")
             target_label = args.get("label")
+            target_uuid = args.get("uuid")
 
-            # Resolve label → socket_path if needed
+            # Build a combined search space: managed + discovered.
+            candidates = []
+            for sp, info in _ctx.instances.items():
+                candidates.append({
+                    "socket_path": sp,
+                    "label": info.get("label"),
+                    "uuid": info.get("uuid"),
+                })
+            for record in _scan_discovery():
+                candidates.append({
+                    "socket_path": record.get("socket_path"),
+                    "label": record.get("label"),
+                    "uuid": record.get("uuid"),
+                })
+
+            # Resolve by uuid → label → socket_path
+            if not target_path and target_uuid:
+                for c in candidates:
+                    if c.get("uuid") == target_uuid:
+                        target_path = c["socket_path"]
+                        break
+                if not target_path:
+                    return [types.TextContent(
+                        type="text",
+                        text=json.dumps({"error": f"No instance with uuid '{target_uuid}'"})
+                    )]
             if not target_path and target_label:
-                for sp, info in _ctx.instances.items():
-                    if info.get("label") == target_label:
-                        target_path = sp
+                for c in candidates:
+                    if c.get("label") == target_label:
+                        target_path = c["socket_path"]
                         break
                 if not target_path:
                     return [types.TextContent(
@@ -1783,7 +1979,7 @@ async def main():
             if not target_path:
                 return [types.TextContent(
                     type="text",
-                    text=json.dumps({"error": "Provide socket_path or label"})
+                    text=json.dumps({"error": "Provide socket_path, label, or uuid"})
                 )]
 
             _ctx.socket_path = target_path
@@ -1879,7 +2075,18 @@ async def main():
                     })
                 )]
 
-            _ctx.register(sock_path, proc.pid, proc, label or sock_path, headless=True)
+            # The spawned process generates its own UUID inside AICopilot.
+            # Look it up from the discovery file so we can store it.
+            instance_uuid = None
+            for record in _scan_discovery(prune_stale=False):
+                if record.get("socket_path") == sock_path:
+                    instance_uuid = record.get("uuid")
+                    break
+
+            _ctx.register(
+                sock_path, proc.pid, proc, label or sock_path,
+                headless=True, instance_uuid=instance_uuid,
+            )
             if select_new:
                 _ctx.socket_path = sock_path
 
@@ -1889,6 +2096,7 @@ async def main():
                     "result": "Headless FreeCAD instance spawned and ready",
                     "socket_path": sock_path,
                     "pid": proc.pid,
+                    "uuid": instance_uuid,
                     "label": label or sock_path,
                     "selected": select_new,
                 })
@@ -1898,7 +2106,13 @@ async def main():
             args = arguments or {}
             target_path = args.get("socket_path")
             target_label = args.get("label")
+            target_uuid = args.get("uuid")
 
+            if not target_path and target_uuid:
+                for sp, info in _ctx.instances.items():
+                    if info.get("uuid") == target_uuid:
+                        target_path = sp
+                        break
             if not target_path and target_label:
                 for sp, info in _ctx.instances.items():
                     if info.get("label") == target_label:
@@ -1908,7 +2122,7 @@ async def main():
             if not target_path:
                 return [types.TextContent(
                     type="text",
-                    text=json.dumps({"error": "Provide socket_path or label of instance to stop"})
+                    text=json.dumps({"error": "Provide socket_path, label, or uuid of instance to stop"})
                 )]
 
             info = _ctx.instances.get(target_path)
@@ -1938,9 +2152,10 @@ async def main():
 
             _ctx.unregister(target_path)
 
-            # If we just stopped the active instance, revert to default
+            # If we just stopped the active instance, clear it so the next
+            # call re-resolves via discovery (or env var if set).
             if _ctx.socket_path == target_path:
-                _ctx.socket_path = os.environ.get("FREECAD_MCP_SOCKET", "/tmp/freecad_mcp.sock")
+                _ctx.socket_path = os.environ.get("FREECAD_MCP_SOCKET")
 
             return [types.TextContent(
                 type="text",

--- a/tests/unit/test_freecad_mcp_handler.py
+++ b/tests/unit/test_freecad_mcp_handler.py
@@ -659,7 +659,9 @@ class TestCallOnGuiThread:
 
 class TestConfiguration:
     def test_default_socket_path(self, ss_module):
-        assert ss_module.SOCKET_PATH == "/tmp/freecad_mcp.sock"
+        # SOCKET_PATH is None when FREECAD_MCP_SOCKET is unset; the real path
+        # is generated per-instance at start_server() time (uuid-suffixed).
+        assert ss_module.SOCKET_PATH is None
 
     def test_default_windows_port(self, ss_module):
         assert ss_module.WINDOWS_PORT == 23456

--- a/tests/unit/test_instance_handlers.py
+++ b/tests/unit/test_instance_handlers.py
@@ -48,6 +48,12 @@ def bridge():
     return _load_bridge()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_discovery(bridge, tmp_path, monkeypatch):
+    """Point DISCOVERY_DIR at an empty tmp path so host state can't leak in."""
+    monkeypatch.setattr(bridge, "DISCOVERY_DIR", str(tmp_path / "instances"))
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_instance_manager.py
+++ b/tests/unit/test_instance_manager.py
@@ -42,6 +42,13 @@ def bridge():
     return _load_bridge()
 
 
+@pytest.fixture(autouse=True)
+def _isolate_discovery(bridge, tmp_path, monkeypatch):
+    """Point DISCOVERY_DIR at an empty tmp path for every test so the host
+    machine's real discovery state cannot leak in."""
+    monkeypatch.setattr(bridge, "DISCOVERY_DIR", str(tmp_path / "instances"))
+
+
 # ===========================================================================
 # _BridgeCtx
 # ===========================================================================
@@ -62,9 +69,11 @@ class TestBridgeCtx:
         assert ctx.socket_path == "/tmp/test_mcp.sock"
 
     def test_default_socket_path_fallback(self, monkeypatch, bridge):
+        # When FREECAD_MCP_SOCKET is unset, the bridge starts with no target;
+        # resolve_target() picks an instance lazily from the discovery dir.
         monkeypatch.delenv("FREECAD_MCP_SOCKET", raising=False)
         ctx = bridge._BridgeCtx()
-        assert ctx.socket_path == "/tmp/freecad_mcp.sock"
+        assert ctx.socket_path is None
 
     def test_register_and_list(self, bridge):
         ctx = bridge._BridgeCtx()
@@ -106,12 +115,25 @@ class TestBridgeCtx:
         ctx.socket_path = str(tmp_path / "nonexistent.sock")
         assert ctx.freecad_available is False
 
-    def test_freecad_available_true_when_socket_exists(self, bridge, tmp_path):
-        sock = tmp_path / "test.sock"
-        sock.touch()
-        ctx = bridge._BridgeCtx()
-        ctx.socket_path = str(sock)
-        assert ctx.freecad_available is True
+    def test_freecad_available_true_when_socket_listens(self, bridge):
+        # freecad_available now probes the socket (connect), not just existence.
+        # Bind+listen a real Unix socket so the probe succeeds. Use /tmp
+        # directly because AF_UNIX paths are length-limited on macOS.
+        import uuid as _uuid
+        sock_path = f"/tmp/freecad_mcp_test_{_uuid.uuid4().hex[:8]}.sock"
+        if os.path.exists(sock_path):
+            os.unlink(sock_path)
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            srv.bind(sock_path)
+            srv.listen(1)
+            ctx = bridge._BridgeCtx()
+            ctx.socket_path = sock_path
+            assert ctx.freecad_available is True
+        finally:
+            srv.close()
+            if os.path.exists(sock_path):
+                os.unlink(sock_path)
 
 
 # ===========================================================================

--- a/tests/unit/test_instance_registry.py
+++ b/tests/unit/test_instance_registry.py
@@ -1,0 +1,176 @@
+"""Tests for AICopilot/instance_registry.py — discovery file write/scan/prune."""
+
+import json
+import os
+import socket
+import sys
+import uuid
+import pytest
+
+AICOPILOT_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "AICopilot")
+sys.path.insert(0, AICOPILOT_DIR)
+
+import instance_registry  # noqa: E402
+
+
+@pytest.fixture
+def isolated_dir(monkeypatch, tmp_path):
+    """Point DISCOVERY_DIR at a fresh tmp path for every test."""
+    target = str(tmp_path / "instances")
+    monkeypatch.setattr(instance_registry, "DISCOVERY_DIR", target)
+    return target
+
+
+@pytest.fixture
+def listen_sock():
+    """Yield a (sock_path, server_socket) pair. Server is listening so probes succeed."""
+    sock_path = f"/tmp/freecad_mcp_test_{uuid.uuid4().hex[:8]}.sock"
+    srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    if os.path.exists(sock_path):
+        os.unlink(sock_path)
+    srv.bind(sock_path)
+    srv.listen(1)
+    try:
+        yield sock_path, srv
+    finally:
+        srv.close()
+        if os.path.exists(sock_path):
+            os.unlink(sock_path)
+
+
+class TestUUIDGeneration:
+    def test_returns_short_hex(self):
+        u = instance_registry.generate_uuid()
+        assert isinstance(u, str)
+        assert len(u) == 12
+        int(u, 16)  # must be valid hex
+
+    def test_unique(self):
+        uuids = {instance_registry.generate_uuid() for _ in range(50)}
+        assert len(uuids) == 50
+
+
+class TestDefaultSocketPath:
+    def test_includes_uuid(self):
+        path = instance_registry.default_socket_path("abc123")
+        assert path == "/tmp/freecad_mcp_abc123.sock"
+
+
+class TestWriteDiscovery:
+    def test_creates_file_with_expected_fields(self, isolated_dir):
+        u = "test12345678"
+        path = instance_registry.write_discovery(
+            u, "/tmp/x.sock", gui=True, label="my-build", freecad_version="1.2.0"
+        )
+        assert os.path.isfile(path)
+        with open(path) as f:
+            data = json.load(f)
+        assert data["uuid"] == u
+        assert data["socket_path"] == "/tmp/x.sock"
+        assert data["gui"] is True
+        assert data["label"] == "my-build"
+        assert data["freecad_version"] == "1.2.0"
+        assert data["pid"] == os.getpid()
+        assert "started_at" in data
+
+    def test_label_defaults_to_uuid(self, isolated_dir):
+        u = "labeluuid001"
+        instance_registry.write_discovery(u, "/tmp/x.sock", gui=False)
+        with open(instance_registry.discovery_path(u)) as f:
+            data = json.load(f)
+        assert data["label"] == u
+
+    def test_atomic_via_rename(self, isolated_dir):
+        # Write twice; the second should completely replace the first.
+        u = "atomicuuid01"
+        instance_registry.write_discovery(u, "/tmp/old.sock", gui=False, label="old")
+        instance_registry.write_discovery(u, "/tmp/new.sock", gui=True, label="new")
+        with open(instance_registry.discovery_path(u)) as f:
+            data = json.load(f)
+        assert data["socket_path"] == "/tmp/new.sock"
+        assert data["label"] == "new"
+        assert data["gui"] is True
+
+
+class TestRemoveDiscovery:
+    def test_removes_existing(self, isolated_dir):
+        u = "remove000001"
+        instance_registry.write_discovery(u, "/tmp/x.sock", gui=False)
+        assert os.path.isfile(instance_registry.discovery_path(u))
+        instance_registry.remove_discovery(u)
+        assert not os.path.exists(instance_registry.discovery_path(u))
+
+    def test_silent_on_missing(self, isolated_dir):
+        # Must not raise even if file doesn't exist
+        instance_registry.remove_discovery("ghost0000001")
+
+
+class TestIsSocketAlive:
+    def test_false_when_path_missing(self, isolated_dir, tmp_path):
+        assert instance_registry.is_socket_alive(str(tmp_path / "nope")) is False
+
+    def test_true_when_listening(self, listen_sock):
+        sock_path, _ = listen_sock
+        assert instance_registry.is_socket_alive(sock_path) is True
+
+    def test_false_when_stale_file(self, isolated_dir):
+        # File exists but nothing is listening
+        stale = f"/tmp/freecad_mcp_test_stale_{uuid.uuid4().hex[:8]}.sock"
+        with open(stale, "w") as f:
+            f.write("")  # not a real socket
+        try:
+            assert instance_registry.is_socket_alive(stale) is False
+        finally:
+            os.unlink(stale)
+
+
+class TestScanDiscovery:
+    def test_empty_when_dir_missing(self, isolated_dir):
+        # isolated_dir points at a path that doesn't exist yet
+        assert instance_registry.scan_discovery() == []
+
+    def test_returns_live_instances(self, isolated_dir, listen_sock):
+        sock_path, _ = listen_sock
+        u = "live00000001"
+        instance_registry.write_discovery(u, sock_path, gui=False, label="alive")
+        result = instance_registry.scan_discovery()
+        assert len(result) == 1
+        assert result[0]["uuid"] == u
+        assert result[0]["socket_path"] == sock_path
+
+    def test_prunes_stale_entries(self, isolated_dir):
+        # Write a discovery file pointing at a socket that doesn't exist
+        u = "stale0000001"
+        instance_registry.write_discovery(u, "/tmp/definitely_not_there.sock",
+                                           gui=False, label="stale")
+        path = instance_registry.discovery_path(u)
+        assert os.path.isfile(path)
+        result = instance_registry.scan_discovery(prune_stale=True)
+        assert result == []
+        assert not os.path.exists(path)  # pruned
+
+    def test_keeps_stale_when_prune_disabled(self, isolated_dir):
+        u = "keeps0000001"
+        instance_registry.write_discovery(u, "/tmp/definitely_not_there.sock",
+                                           gui=False, label="stale")
+        path = instance_registry.discovery_path(u)
+        instance_registry.scan_discovery(prune_stale=False)
+        assert os.path.exists(path)  # still there
+
+    def test_prunes_unreadable_json(self, isolated_dir):
+        instance_registry.ensure_dir()
+        bad_path = os.path.join(isolated_dir, "garbage.json")
+        with open(bad_path, "w") as f:
+            f.write("not-json{")
+        result = instance_registry.scan_discovery(prune_stale=True)
+        assert result == []
+        assert not os.path.exists(bad_path)
+
+    def test_ignores_non_json_files(self, isolated_dir, listen_sock):
+        sock_path, _ = listen_sock
+        instance_registry.write_discovery("realuuid0001", sock_path, gui=False)
+        # Add a non-.json file that should be ignored
+        with open(os.path.join(isolated_dir, "README.txt"), "w") as f:
+            f.write("hello")
+        result = instance_registry.scan_discovery()
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

PR-A of the multi-GUI series. Foundation + discovery — every FreeCAD process is now uniquely identified and discoverable; the bridge can resolve which one to talk to without manual env-var discipline.

- New \`AICopilot/instance_registry.py\` — atomic discovery file write/remove/scan at \`~/.cache/freecad-mcp/instances/<uuid>.json\`
- Each AICopilot process (GUI or headless) generates a UUID at startup, binds \`/tmp/freecad_mcp_<uuid>.sock\` by default, writes its discovery record
- Bridge \`_BridgeCtx\` rewritten: no legacy default; \`resolve_target()\` does 0/1/N discovery logic (auto-select when one, require explicit selection when many)
- \`select_freecad_instance\` and \`stop_freecad_instance\` accept \`uuid\` as a selector in addition to \`label\` / \`socket_path\`
- \`list_freecad_instances\` merges bridge-spawned + discovered instances into one view, annotated with uuid / gui / version / label

## Correctness fixes the design surfaced

1. **Silent socket theft fixed** ([freecad_mcp_handler.py](AICopilot/freecad_mcp_handler.py) \`start_server\`) — used to unconditionally \`os.remove\` an existing socket then bind, which silently stole the socket from any live peer. Now probes (connect) first and refuses to start if the path is live.
2. **Crash watcher per-PID** ([crash_watcher.py](AICopilot/crash_watcher.py)) — \`LAST_OP_FILE\` is now \`/tmp/freecad_mcp_last_op_<pid>.json\`. \`freecad_crash_report.diagnose()\` accepts a pid; the bridge plumbs it through from \`_ctx\` (managed) or discovery (unmanaged).

## Backward compat

- \`FREECAD_MCP_SOCKET\` env var still wins when explicitly set
- \`FREECAD_MCP_LABEL\` (new) lets launchers pre-name an instance for friendlier listing
- The legacy global \`/tmp/freecad_mcp.sock\` path is deprecated; no symlink shim per design discussion (user base too small to justify the carrying cost)
- Bumps to 5.8.0 land in the final release-prep PR after PR-B (GUI spawn) and PR-C (tests/docs)

## What's next

- **PR-B**: Add \`gui=True\` to \`spawn_freecad_instance\` + \`_find_freecad_gui()\` helper + 60s readiness timeout
- **PR-C**: Doc-label round-trip enrichment in \`list_freecad_instances\`, integration tests for the two-headless scenario, README updates
- **PR-D**: Version bump to 5.8.0 + server.json

## Test plan

- [x] Full unit suite passes: 906 passing (889 baseline + 17 new \`test_instance_registry\`)
- [x] AST parse check on all edited files
- [ ] Manual GUI test: launch two FreeCAD GUIs with distinct \`FREECAD_MCP_LABEL\` env vars, verify both appear in \`list_freecad_instances\`, switch between with \`select_freecad_instance uuid=...\`
- [ ] Manual headless test: \`spawn_freecad_instance\` twice, verify uuid is filled in from discovery file
- [ ] Integration test for two-headless scenario (slated for PR-C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)