### PR TITLE
chore(release): 5.8.0 — multi-instance + concurrent GUI

### DIFF
--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -1,13 +1,15 @@
 # FreeCAD Socket Server for MCP Communication
 # Runs inside FreeCAD to receive commands from external MCP bridge
 #
-# Version: 5.5.0 - All handler dispatches use async GUI path; progressive
-#                   poll backoff in bridge (50ms→1s); 2-min poll ceiling
+# Version: 5.8.0 - Multi-instance discovery via per-instance UUID +
+#                   ~/.cache registry; GUI spawn + explicit freecad_binary;
+#                   list_freecad_instances enriched with active doc + window
+#                   title; startup banner shows handler version.
 
 # Minimum FreeCAD version required for CAM tools.
 # Below this, cam_operations / cam_tools / cam_tool_controllers return a clean
 # "not supported" error rather than crashing on missing Path/CAM API.
-__version__ = "5.5.0"
+__version__ = "5.8.0"
 
 CAM_MIN_FC_VERSION = (1, 2, 0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freecad-mcp"
-version = "5.7.0"
+version = "5.8.0"
 description = "MCP server to control FreeCAD from Claude"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.blwfish/freecad-mcp",
   "title": "FreeCAD MCP",
   "description": "Control FreeCAD from Claude — 3D modeling, PartDesign, CAM toolpaths, and more via 30+ tools.",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "repository": {
     "url": "https://github.com/blwfish/freecad-mcp",
     "source": "github"


### PR DESCRIPTION
## Summary

Version bump for the multi-instance work that just landed (PRs #9 → #10 → #11). Snaps everything to 5.8.0:

- `pyproject.toml` 5.7.0 → 5.8.0
- `server.json` 5.7.0 → 5.8.0 (MCP registry)
- `AICopilot/freecad_mcp_handler.__version__` **5.5.0 → 5.8.0** — the handler had drifted behind the project version; the startup banner added in #11 reads from this, so this also fixes a user-visible inconsistency (banner would have said `v5.5.0` on a 5.8.0 release otherwise).

Version intentionally 5.8.0 not 6.0.0 — no breaking surface change.

## What 5.8.0 contains (since 5.7.0)

- **#9** — Foundations: per-instance UUID, `~/.cache/freecad-mcp/instances/<uuid>.json` discovery registry, probe-before-unlink fix for the socket-theft bug, per-PID crash watcher files, `_BridgeCtx.resolve_target()` with 0/1/N logic.
- **#10** — `spawn_freecad_instance` learned `gui=true|false` and `freecad_binary=<path>`. macOS targets the inner Mach-O to dodge `open`'s app-dedup.
- **#11** — `list_freecad_instances` enriched with `active_doc_label`, `window_title`, `freecad_version` via parallel `get_instance_info` fan-out; 5s info cache; README docs; startup banner shows handler version.

Aggregate diff across the three: +1.4k / -100 LOC, 25 new unit tests (893 → 918 passing).

## Test plan

- [x] `pytest tests/unit/` — 918 passing on this branch
- [ ] CI matrix on the PR (Ubuntu+macOS × Python 3.10/3.12/3.13, FreeCAD 1.1-stable + 1.2-dev)
- [ ] After merge, tag `v5.8.0` to fire release.yml (git-cliff generates RELEASE_NOTES.md, softprops/action-gh-release creates the GitHub Release)

## CHANGELOG.md note

Not updated in this PR — the on-disk CHANGELOG.md hasn't been kept current beyond 5.1.0, and release.yml regenerates release notes from `git log` via git-cliff at tag time, so the canonical changelog lives in the GitHub Release. Happy to add a back-fill PR if you want the on-disk file to catch up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)