### PR TITLE
Fix evaluate_expr substring collision in parametric_helpers

### DIFF
--- a/helpers/parametric_helpers.py
+++ b/helpers/parametric_helpers.py
@@ -86,20 +86,24 @@ class ParametricHelpers:
         except (ValueError, TypeError):
             pass
 
-        # Try to interpret as an expression
-        # Replace parameter names with their values
+        # Substitute each identifier token with its parameter value in a single
+        # pass via re.sub. Using str.replace per token is substring-based and
+        # corrupts identifiers that contain other identifiers as prefixes
+        # (e.g. param "w" mangling identifier "width"). A re.sub callback over
+        # the same \b...\w*\b token pattern operates on whole identifiers and
+        # never revisits previously substituted text.
         import re
-        result_expr = expr
 
-        # Find all word-like tokens and try to replace them with param values
-        tokens = re.findall(r'\b[a-zA-Z_]\w*\b', expr)
-        for token in tokens:
+        def _replace(match):
+            token = match.group(0)
             try:
-                val = self.get_param(token)
-                result_expr = result_expr.replace(token, str(val))
+                return str(self.get_param(token))
             except ValueError:
-                # Not a parameter, might be a unit like "mm" or "ft"
-                pass
+                # Not a parameter, might be a unit like "mm" or "ft" or an
+                # identifier the eval below will catch.
+                return token
+
+        result_expr = re.sub(r'\b[a-zA-Z_]\w*\b', _replace, expr)
 
         # Restricted eval: disable builtins to prevent arbitrary code execution.
         # Only numeric literals and arithmetic operators should remain after token substitution.

--- a/tests/unit/test_parametric_helpers.py
+++ b/tests/unit/test_parametric_helpers.py
@@ -1,0 +1,99 @@
+"""
+Unit tests for helpers/parametric_helpers.py.
+
+Focus: evaluate_expr identifier substitution. The original implementation
+used str.replace to substitute parameter names with their numeric values,
+which is substring-based and corrupts names that are substrings of other
+names (e.g. param "w" substituted inside identifier "width").
+"""
+
+import os
+import sys
+import pytest
+
+
+# Make sure the repo's `helpers/` package can be imported. tests/unit/conftest
+# already mocks FreeCAD before any import happens.
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
+
+@pytest.fixture(autouse=True)
+def _patch_freecad_vector(mock_freecad):
+    """parametric_helpers does ``from FreeCAD import Vector`` at import time.
+
+    The shared mock_freecad fixture in conftest doesn't define Vector, so add
+    a stub before the module under test is imported.
+    """
+    if not hasattr(mock_freecad, "Vector"):
+        mock_freecad.Vector = lambda *a, **kw: None
+    yield
+
+
+def _make_helpers(params: dict):
+    """Build a ParametricHelpers with get_param backed by a plain dict.
+
+    Skips real __init__ (which needs an active document + params sheet).
+    """
+    from helpers.parametric_helpers import ParametricHelpers
+
+    obj = ParametricHelpers.__new__(ParametricHelpers)
+
+    def _get_param(alias):
+        if alias in params:
+            return params[alias]
+        raise ValueError(f"Parameter '{alias}' not found")
+
+    obj.get_param = _get_param  # type: ignore[attr-defined]
+    return obj
+
+
+class TestEvaluateExpr:
+    def test_plain_number_string(self):
+        ph = _make_helpers({})
+        assert ph.evaluate_expr("42") == 42.0
+
+    def test_single_param(self):
+        ph = _make_helpers({"width": 100.0})
+        assert ph.evaluate_expr("width") == 100.0
+
+    def test_param_with_arithmetic(self):
+        ph = _make_helpers({"width": 100.0})
+        assert ph.evaluate_expr("width/2") == 50.0
+
+    def test_two_disjoint_params(self):
+        ph = _make_helpers({"a": 3, "b": 4})
+        assert ph.evaluate_expr("a + b") == 7
+
+    def test_substring_param_names_short_then_long(self):
+        """`w` is a substring of `width`; both are valid params.
+
+        Naive str.replace iterates tokens and replaces all occurrences of
+        each, so replacing `w` first corrupts `width` to `<val>idth`. The
+        semantically correct behaviour is to substitute identifiers, not
+        substrings.
+        """
+        ph = _make_helpers({"w": 3, "width": 100})
+        assert ph.evaluate_expr("w + width") == 103
+
+    def test_substring_param_names_long_then_short(self):
+        ph = _make_helpers({"w": 3, "width": 100})
+        # Same params, opposite source-order: result must not depend on
+        # which token the regex happens to yield first.
+        assert ph.evaluate_expr("width + w") == 103
+
+    def test_param_name_is_substring_of_non_param_identifier(self):
+        """`x` is a param; expression mentions `xMax`, which is not a param.
+
+        Substring replace would mangle `xMax` into `5Max` and the eval would
+        fail. Caller has used a parameter that doesn't exist — the right
+        outcome is a ValueError from evaluate_expr, not a corrupted token.
+        """
+        ph = _make_helpers({"x": 5})
+        with pytest.raises(ValueError):
+            ph.evaluate_expr("x + xMax")
+
+    def test_repeated_param_use(self):
+        ph = _make_helpers({"w": 4})
+        assert ph.evaluate_expr("w * w") == 16


### PR DESCRIPTION
## Summary

`helpers/parametric_helpers.py::evaluate_expr` substituted parameter values into expressions by extracting identifier tokens with a word-boundary regex, then calling `str.replace` for each token. `str.replace` is substring-based, not identifier-based, so when one parameter name was a prefix of another the shorter name's substitution corrupted the longer one.

Concrete example with params `{w: 3, width: 100}`:

- `evaluate_expr("w + width")` -> `ValueError: Failed to evaluate expression 'w + width': invalid decimal literal` (silent corruption: `"w + width"` becomes `"3 + 3idth"`)
- `evaluate_expr("width + w")` -> `103` (works by accident, because `re.findall` yields `width` first)

The bug was found by an audit for "semantic intent expressed syntactically as regex": the operation was "rebind these identifiers", but the implementation flattened that into substring find/replace. Order-dependent silent miscalculation is the worst kind of bug to ship in a parametric-modeling helper.

The fix replaces the token-extract + per-token replace loop with a single `re.sub` pass that walks the expression left-to-right and substitutes whole identifiers via callback, so substituted text is never rescanned and prefix params can't collide with longer names.

## Test plan

- [x] New test file `tests/unit/test_parametric_helpers.py` with 8 tests covering plain numbers, single params, arithmetic, two disjoint params, both orderings of substring-collision params, param-name-as-prefix-of-unknown-identifier, and repeated-param-use
- [x] First commit adds the tests; the substring-collision test fails on the unfixed code (pinning the bug). Second commit applies the fix; all 8 tests pass.
- [x] Full unit suite (`pytest tests/unit/`) passes: 957 passed, 1 xfailed (pre-existing), no regressions.

Audit report: 15 total `re.*` sites in the repo, 13 appropriate (test counting, source tokenization, semver, spreadsheet cell refs), 1 confirmed bug (this one), 1 needs-human-review (spreadsheet cell-ref regex lacks `^...$` anchors so `"A1garbage"` is accepted as `A1` — low risk, structured MCP input, not addressed here).