### PR TITLE
chore(release): 5.8.1

### DIFF
--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -9,7 +9,7 @@
 # Minimum FreeCAD version required for CAM tools.
 # Below this, cam_operations / cam_tools / cam_tool_controllers return a clean
 # "not supported" error rather than crashing on missing Path/CAM API.
-__version__ = "5.8.0"
+__version__ = "5.8.1"
 
 CAM_MIN_FC_VERSION = (1, 2, 0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freecad-mcp"
-version = "5.8.0"
+version = "5.8.1"
 description = "MCP server to control FreeCAD from Claude"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.blwfish/freecad-mcp",
   "title": "FreeCAD MCP",
   "description": "Control FreeCAD from Claude — 3D modeling, PartDesign, CAM toolpaths, and more via 30+ tools.",
-  "version": "5.8.0",
+  "version": "5.8.1",
   "repository": {
     "url": "https://github.com/blwfish/freecad-mcp",
     "source": "github"


### PR DESCRIPTION
Version bump to 5.8.1.

## Changes since 5.8.0

- fix: remove auto-document-creation from primitive and sketch handlers (#19) — `get_document()` no longer calls `FreeCAD.newDocument()`; primitives and `create_sketch` return a clear error when no document is open, directing callers to `view_control(create_document)` first. Fixes the macOS SIGABRT reported in issue #16.

## Test plan
- [ ] CI green on merge
- [ ] Tag v5.8.1 after merge triggers release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)