### PR TITLE
Release 5.10.0 — whole-repo review remediation

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -53,14 +53,14 @@ jobs:
         # alert-state is set only on security PRs (regardless of severity).
         # Security fixes auto-merge whenever CI passes — we want them in fast.
         if: steps.meta.outputs.alert-state != ''
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto-merge patch version updates
         if: steps.meta.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
             new_mm=$(echo "$new" | cut -d. -f1,2)
             if [ "$prev_mm" = "$new_mm" ] && [ "$prev" != "$new" ]; then
               echo "Patch-only constraint bump: $prev → $new — enabling auto-merge"
-              gh pr merge --auto --merge "$PR_URL"
+              gh pr merge --auto --rebase "$PR_URL"
               exit 0
             fi
           fi

--- a/AICopilot/crash_watcher.py
+++ b/AICopilot/crash_watcher.py
@@ -38,7 +38,13 @@ def set_current_op(tool: str, args: dict) -> None:
     safe_args = {}
     for k, v in args.items():
         s = str(v)
-        safe_args[k] = (s[:_MAX_ARG_BYTES] + " … [truncated]") if len(s) > _MAX_ARG_BYTES else s
+        # _MAX_ARG_BYTES is a BYTE limit — truncate on the encoded bytes, not the
+        # character count, so multibyte UTF-8 args don't blow past it.
+        b = s.encode("utf-8")
+        if len(b) > _MAX_ARG_BYTES:
+            safe_args[k] = b[:_MAX_ARG_BYTES].decode("utf-8", errors="ignore") + " … [truncated]"
+        else:
+            safe_args[k] = s
 
     data = {
         "tool":       tool,

--- a/AICopilot/freecad_health.py
+++ b/AICopilot/freecad_health.py
@@ -35,6 +35,7 @@ import json
 import os
 import signal
 import socket
+import struct
 import subprocess
 import time
 from datetime import datetime
@@ -119,19 +120,27 @@ class FreeCADHealthMonitor:
             
             try:
                 sock.connect(str(self.socket_path))
-                # Try a simple ping/echo test
-                test_msg = json.dumps({"method": "test_echo", "params": {"message": "ping"}})
-                sock.sendall(test_msg.encode() + b'\n')
-                
-                # Wait for response
-                response = sock.recv(4096)
-                if response:
-                    if not self.lean_logging:
-                        self.logger.debug("Socket is responsive")
-                    return True, None
-                else:
-                    return False, "Socket connected but no response"
-                    
+                # The handler speaks length-prefixed framing (4-byte big-endian
+                # length + UTF-8 JSON) and dispatches on {"tool", "args"}. A
+                # newline-delimited {"method": ...} message is misframed — the
+                # handler reads the first 4 bytes as a huge length and blocks —
+                # so this check must use the real wire protocol. Any framed reply
+                # (even "Unknown tool") proves the socket is responsive.
+                request = json.dumps(
+                    {"tool": "test_echo", "args": {"message": "ping"}}
+                ).encode("utf-8")
+                sock.sendall(struct.pack(">I", len(request)) + request)
+
+                header = self._recv_exact(sock, 4)
+                if header is None:
+                    return False, "Socket connected but closed without responding"
+                resp_len = struct.unpack(">I", header)[0]
+                if self._recv_exact(sock, resp_len) is None:
+                    return False, "Socket connected but response truncated"
+                if not self.lean_logging:
+                    self.logger.debug("Socket is responsive")
+                return True, None
+
             except socket.timeout:
                 return False, "Socket connection timeout"
             except ConnectionRefusedError:
@@ -141,7 +150,18 @@ class FreeCADHealthMonitor:
                 
         except Exception as e:
             return False, f"Socket check failed: {e}"
-    
+
+    @staticmethod
+    def _recv_exact(sock: socket.socket, num_bytes: int) -> Optional[bytes]:
+        """Read exactly num_bytes from sock, or None if it closes early."""
+        buf = bytearray()
+        while len(buf) < num_bytes:
+            chunk = sock.recv(min(num_bytes - len(buf), 65536))
+            if not chunk:
+                return None
+            buf.extend(chunk)
+        return bytes(buf)
+
     def check_freecad_process(self) -> Tuple[bool, Optional[int]]:
         """
         Check if FreeCAD process is running.

--- a/AICopilot/freecad_health.py
+++ b/AICopilot/freecad_health.py
@@ -275,10 +275,14 @@ class FreeCADHealthMonitor:
         except Exception as e:
             crash_info["freecad_state"] = {"error": str(e)}
         
-        # Save crash log
+        # Save crash log — guard the write so a disk/permission error doesn't
+        # unwind the health-monitor loop and lose the crash record entirely.
         crash_file = self.crash_log_dir / f"crash_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
-        with open(crash_file, 'w') as f:
-            json.dump(crash_info, f, indent=2)
+        try:
+            with open(crash_file, 'w') as f:
+                json.dump(crash_info, f, indent=2)
+        except Exception as e:
+            self.logger.error(f"Failed to write crash log {crash_file}: {e}")
         
         # Add to crash history
         self.crash_history.append(crash_info)

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -1322,12 +1322,14 @@ class FreeCADSocketServer:
             # Document mutations — must run on GUI thread (recompute touches Qt)
             "rollback_to_checkpoint": self.document_ops.rollback_to_checkpoint,
             "insert_shape":           self.document_ops.insert_shape,
+            # save()/saveAs() emit modified/title signals the GUI observes; on
+            # macOS a save from the socket thread trips the main-thread assert.
+            "save_document":          self.document_ops.save_document,
         }
 
         # --- Operations safe to call from any thread ---
         safe_ops = {
             "create_document":      self.document_ops.create_document,
-            "save_document":        self.document_ops.save_document,
             "list_objects":         self.document_ops.list_objects,
             "get_object_properties": self.document_ops.get_object_properties,
             # checkpoint only reads names — thread-safe

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -191,6 +191,14 @@ def send_message(sock: socket.socket, message_str: str) -> bool:
     """Send a length-prefixed message over the socket."""
     try:
         message_bytes = message_str.encode('utf-8')
+        # Refuse to put an oversized frame on the wire: the peer rejects the body
+        # after the length prefix, desyncing every subsequent frame.
+        if len(message_bytes) > MAX_MESSAGE_SIZE:
+            FreeCAD.Console.PrintError(
+                f"Refusing to send oversized message: {len(message_bytes)} bytes "
+                f"(limit: {MAX_MESSAGE_SIZE}); would desync framing.\n"
+            )
+            return False
         length_prefix = struct.pack('>I', len(message_bytes))
         sock.sendall(length_prefix + message_bytes)
         return True
@@ -201,13 +209,12 @@ def send_message(sock: socket.socket, message_str: str) -> bool:
 
 def receive_message(sock: socket.socket, timeout: float = 30.0) -> Optional[str]:
     """Receive a length-prefixed message from the socket."""
+    old_timeout = sock.gettimeout()
     try:
-        old_timeout = sock.gettimeout()
         sock.settimeout(timeout)
 
         length_bytes = _recv_exact(sock, 4)
-        if not length_bytes:
-            sock.settimeout(old_timeout)
+        if length_bytes is None:
             return None
 
         message_len = struct.unpack('>I', length_bytes)[0]
@@ -216,12 +223,13 @@ def receive_message(sock: socket.socket, timeout: float = 30.0) -> Optional[str]
             FreeCAD.Console.PrintError(
                 f"Message too large: {message_len} bytes (limit: {MAX_MESSAGE_SIZE})\n"
             )
-            sock.settimeout(old_timeout)
             return None
 
+        # message_len may legitimately be 0 (empty-body frame); _recv_exact returns
+        # b'' for that and None only on a closed connection. Distinguish with
+        # `is None` so a valid empty frame is not misread as a disconnect.
         message_bytes = _recv_exact(sock, message_len)
-        sock.settimeout(old_timeout)
-        if not message_bytes:
+        if message_bytes is None:
             return None
 
         return message_bytes.decode('utf-8')
@@ -235,6 +243,9 @@ def receive_message(sock: socket.socket, timeout: float = 30.0) -> Optional[str]
     except Exception as e:
         FreeCAD.Console.PrintError(f"Receive error: {e}\n")
         return None
+    finally:
+        # Always restore the caller's timeout, even on an exception path.
+        sock.settimeout(old_timeout)
 
 
 def _recv_exact(sock: socket.socket, num_bytes: int) -> Optional[bytes]:
@@ -700,6 +711,7 @@ class FreeCADSocketServer:
                 return json.dumps({
                     "status": "error",
                     "error": task_result["error"],
+                    "error_id": task_result.get("error_id"),
                     "elapsed_s": round(job.get("elapsed", elapsed), 1),
                 })
             result_val = task_result.get("result", "done") if isinstance(task_result, dict) else str(task_result)
@@ -712,6 +724,7 @@ class FreeCADSocketServer:
             return json.dumps({
                 "status": "error",
                 "error": job.get("error", "unknown error"),
+                "error_id": job.get("error_id"),
                 "elapsed_s": round(job.get("elapsed", elapsed), 1),
             })
 

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -9,7 +9,7 @@
 # Minimum FreeCAD version required for CAM tools.
 # Below this, cam_operations / cam_tools / cam_tool_controllers return a clean
 # "not supported" error rather than crashing on missing Path/CAM API.
-__version__ = "5.9.0"
+__version__ = "5.10.0"
 
 CAM_MIN_FC_VERSION = (1, 2, 0)
 

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -754,6 +754,9 @@ class FreeCADSocketServer:
             "status": "error",
             "error": f"Cancelled by user after {elapsed}s",
             "elapsed": elapsed,
+            # TTL cleanup measures retention from "finished" (see ASYNC_JOB_TTL);
+            # without it a cancelled job is retained relative to its start time.
+            "finished": time.time(),
         })
 
         # Attempt to set the FreeCAD cancellation flag (works for PartDesign/Thickness ops;
@@ -787,7 +790,8 @@ class FreeCADSocketServer:
             jid: {
                 "status": j["status"],
                 "elapsed_s": round(now - j["started"], 1),
-                "tool": j.get("tool", "?"),
+                # async jobs carry 'label', sync ones 'tool' — fall back so neither shows '?'
+                "tool": j.get("tool") or j.get("label") or "?",
             }
             for jid, j in self._async_jobs.items()
         }
@@ -1700,6 +1704,7 @@ class FreeCADSocketServer:
             latest_log = max(log_files, key=os.path.getmtime)
 
             entries = []
+            skipped_malformed = 0
             with open(latest_log, "r") as f:
                 lines = f.readlines()
                 for line in lines[-count:]:
@@ -1709,13 +1714,17 @@ class FreeCADSocketServer:
                             continue
                         entries.append(entry)
                     except json.JSONDecodeError:
+                        skipped_malformed += 1
                         continue
 
-            return json.dumps({
+            result = {
                 "result": f"Retrieved {len(entries)} log entries from {os.path.basename(latest_log)}",
                 "log_file": latest_log,
                 "entries": entries,
-            })
+            }
+            if skipped_malformed:
+                result["skipped_malformed"] = skipped_malformed
+            return json.dumps(result)
 
         except Exception as e:
             return json.dumps({"error": f"Failed to retrieve debug logs: {e}"})

--- a/AICopilot/handlers/base.py
+++ b/AICopilot/handlers/base.py
@@ -224,6 +224,29 @@ class BaseHandler:
                     f"this large may crash FreeCAD. Consider simplifying first.")
         return None
 
+    def feed_to_mm_min(self, value):
+        """Convert a FreeCAD feed property to a numeric value in mm/min.
+
+        CAM feed/rapid properties (HorizFeed, VertFeed, ...) are App::PropertySpeed
+        velocity Quantities whose base unit is mm/s. Reading the raw property and
+        string-splitting it is fragile — the formatted string's unit depends on the
+        user's unit schema (mm/s, m/s, ...), so a fixed ``* 60`` is wrong under any
+        non-default schema. ``Quantity.getValueAs('mm/min')`` is exact regardless.
+
+        Returns the mm/min value as a float, or None if it can't be interpreted.
+        """
+        if value is None:
+            return None
+        try:
+            q = value if hasattr(value, 'getValueAs') else FreeCAD.Units.Quantity(value)
+            return float(q.getValueAs('mm/min'))
+        except Exception:
+            # Last-resort fallback: assume the raw magnitude is already in mm/s.
+            try:
+                return float(str(value).split()[0]) * 60.0
+            except Exception:
+                return None
+
     def find_body(self, doc: FreeCAD.Document = None):
         """Find a PartDesign Body in the document.
 

--- a/AICopilot/handlers/boolean_ops.py
+++ b/AICopilot/handlers/boolean_ops.py
@@ -79,11 +79,18 @@ class BooleanOpsHandler(BaseHandler):
             # Safety: save before risky op
             self.save_before_risky_op(doc)
 
-            # Create cut and hide sources
+            # Create cut and hide sources. Part::Cut.Tool is a single reference
+            # (assigning a list raises "Type must be App.DocumentObject or None,
+            # not list"), so fuse multiple tools into one before cutting.
             cut = doc.addObject("Part::Cut", name)
             cut.Label = name
             cut.Base = base_obj
-            cut.Tool = tool_objs[0] if len(tool_objs) == 1 else tool_objs
+            if len(tool_objs) == 1:
+                cut.Tool = tool_objs[0]
+            else:
+                fusion = doc.addObject("Part::MultiFuse", f"{name}_Tools")
+                fusion.Shapes = tool_objs
+                cut.Tool = fusion
             self.recompute(doc)
             base_obj.Visibility = False
             for obj in tool_objs:

--- a/AICopilot/handlers/boolean_ops.py
+++ b/AICopilot/handlers/boolean_ops.py
@@ -41,6 +41,12 @@ class BooleanOpsHandler(BaseHandler):
             fusion.Label = name
             fusion.Shapes = objs
             self.recompute(doc)
+            # Verify the boolean produced a real shape BEFORE hiding the sources —
+            # OCCT can yield a null shape (non-manifold/coincident geometry) without
+            # raising, which would otherwise leave the user with a hidden, empty result.
+            if not getattr(fusion, 'Shape', None) or fusion.Shape.isNull():
+                return (f"Fusion produced an empty/invalid shape — sources left visible "
+                        f"(check for non-manifold or coincident geometry)")
             for obj in objs:
                 obj.Visibility = False
 
@@ -92,6 +98,9 @@ class BooleanOpsHandler(BaseHandler):
                 fusion.Shapes = tool_objs
                 cut.Tool = fusion
             self.recompute(doc)
+            if not getattr(cut, 'Shape', None) or cut.Shape.isNull():
+                return (f"Cut produced an empty/invalid shape — sources left visible "
+                        f"(the tools may fully consume the base, or geometry is degenerate)")
             base_obj.Visibility = False
             for obj in tool_objs:
                 obj.Visibility = False
@@ -134,6 +143,11 @@ class BooleanOpsHandler(BaseHandler):
             common.Label = name
             common.Shapes = objs
             self.recompute(doc)
+            # An empty intersection is a legitimate geometric answer (no overlap),
+            # but hiding the sources and reporting success would hide that fact.
+            if not getattr(common, 'Shape', None) or common.Shape.isNull():
+                return (f"Intersection is empty — the objects do not overlap; "
+                        f"sources left visible")
             for obj in objs:
                 obj.Visibility = False
 

--- a/AICopilot/handlers/cam_ops.py
+++ b/AICopilot/handlers/cam_ops.py
@@ -573,6 +573,9 @@ class CAMOpsHandler(BaseHandler):
                     result += f"     Side: {op.Side}\n"
                 if hasattr(op, 'Direction'):
                     result += f"     Direction: {op.Direction}\n"
+                # Disabled operations emit no G-code — surface this so it isn't silent.
+                if hasattr(op, 'Active'):
+                    result += f"     Active: {op.Active}\n"
 
             return self.log_and_return("list_operations", args, result=result, duration=time.time() - start_time)
 
@@ -613,6 +616,10 @@ class CAMOpsHandler(BaseHandler):
 
             result = f"Operation: {operation.Label}\n"
             result += f"  Type: {operation.TypeId}\n"
+            # Active flag is critical: a disabled operation is silently skipped
+            # during post-processing and emits NO G-code.
+            if hasattr(operation, 'Active'):
+                result += f"  Active: {operation.Active}\n"
 
             # Show all relevant properties
             if hasattr(operation, 'ToolController') and operation.ToolController:
@@ -647,6 +654,12 @@ class CAMOpsHandler(BaseHandler):
                 result += f"  Safe Height: {operation.SafeHeight}\n"
             if hasattr(operation, 'ClearanceHeight'):
                 result += f"  Clearance Height: {operation.ClearanceHeight}\n"
+            # Operation-specific params (drilling, adaptive) — present only on
+            # the relevant op types; emit whichever exist rather than dropping them.
+            for prop, label in (("PeckDepth", "Peck Depth"), ("DwellTime", "Dwell Time"),
+                                ("RetractHeight", "Retract Height"), ("Tolerance", "Tolerance")):
+                if hasattr(operation, prop):
+                    result += f"  {label}: {getattr(operation, prop)}\n"
 
             return self.log_and_return("get_operation", args, result=result, duration=time.time() - start_time)
 

--- a/AICopilot/handlers/cam_ops.py
+++ b/AICopilot/handlers/cam_ops.py
@@ -623,8 +623,9 @@ class CAMOpsHandler(BaseHandler):
                 if hasattr(tc, 'SpindleSpeed'):
                     result += f"    Spindle Speed: {tc.SpindleSpeed} RPM\n"
                 if hasattr(tc, 'HorizFeed'):
-                    feed_mmpm = float(str(tc.HorizFeed).split()[0]) * 60
-                    result += f"    Feed Rate: {feed_mmpm:.0f} mm/min\n"
+                    feed_mmpm = self.feed_to_mm_min(tc.HorizFeed)
+                    if feed_mmpm is not None:
+                        result += f"    Feed Rate: {feed_mmpm:.0f} mm/min\n"
 
             if hasattr(operation, 'Base'):
                 result += f"  Base Object: {operation.Base}\n"

--- a/AICopilot/handlers/cam_ops.py
+++ b/AICopilot/handlers/cam_ops.py
@@ -1063,7 +1063,12 @@ class CAMOpsHandler(BaseHandler):
         start_time = time.time()
         try:
             result = self.post_process(args)
-            # Log this as export_gcode even though it delegates to post_process
+            # post_process returns a plain string; if it's an error, log it as a
+            # failure rather than recording a failed export as a success.
+            if isinstance(result, str) and result.lstrip().startswith("Error"):
+                return self.log_and_return("export_gcode", args,
+                                           error=Exception(result),
+                                           duration=time.time() - start_time)
             return self.log_and_return("export_gcode", args, result=result, duration=time.time() - start_time)
         except Exception as e:
             return self.log_and_return("export_gcode", args, error=e, duration=time.time() - start_time)

--- a/AICopilot/handlers/cam_tool_controllers.py
+++ b/AICopilot/handlers/cam_tool_controllers.py
@@ -295,8 +295,23 @@ class CAMToolControllersHandler(BaseHandler):
                 controller.ToolNumber = args['tool_number']
                 updates.append(f"tool_number: T{args['tool_number']}")
 
+            # These are readable via get_tool_controller but previously had no
+            # write path, so they were frozen after creation. Rapids are velocity
+            # Quantities (mm/s base), same mm/min->mm/s convention as feeds.
+            if 'spindle_dir' in args:
+                controller.SpindleDir = args['spindle_dir']
+                updates.append(f"spindle_dir: {args['spindle_dir']}")
+
+            if 'horiz_rapid' in args:
+                controller.HorizRapid = args['horiz_rapid'] / 60.0  # mm/min -> mm/s
+                updates.append(f"horiz_rapid: {args['horiz_rapid']} mm/min")
+
+            if 'vert_rapid' in args:
+                controller.VertRapid = args['vert_rapid'] / 60.0  # mm/min -> mm/s
+                updates.append(f"vert_rapid: {args['vert_rapid']} mm/min")
+
             if not updates:
-                error = Exception("No parameters to update. Provide spindle_speed, feed_rate, vertical_feed_rate, or tool_number.")
+                error = Exception("No parameters to update. Provide spindle_speed, feed_rate, vertical_feed_rate, tool_number, spindle_dir, horiz_rapid, or vert_rapid.")
                 return self.log_and_return("update_tool_controller", args, error=error, duration=time.time() - start_time)
 
             self.recompute(doc)

--- a/AICopilot/handlers/cam_tool_controllers.py
+++ b/AICopilot/handlers/cam_tool_controllers.py
@@ -148,9 +148,10 @@ class CAMToolControllersHandler(BaseHandler):
             for i, tc in enumerate(controllers, 1):
                 tool_name = tc.Tool.Label if hasattr(tc, 'Tool') and tc.Tool else 'None'
                 speed = tc.SpindleSpeed if hasattr(tc, 'SpindleSpeed') else 'N/A'
-                # FC 1.2 stores feed in mm/s; display as mm/min
-                feed_mms = tc.HorizFeed if hasattr(tc, 'HorizFeed') else None
-                feed = f"{float(str(feed_mms).split()[0]) * 60:.0f}" if feed_mms is not None else 'N/A'
+                # FC 1.2 stores feed as a velocity Quantity (base unit mm/s); convert
+                # to mm/min exactly rather than string-splitting the formatted value.
+                feed_val = self.feed_to_mm_min(tc.HorizFeed) if hasattr(tc, 'HorizFeed') else None
+                feed = f"{feed_val:.0f}" if feed_val is not None else 'N/A'
                 tool_num = tc.ToolNumber if hasattr(tc, 'ToolNumber') else 'N/A'
 
                 result += f"  {i}. {tc.Label} (T{tool_num})\n"
@@ -219,14 +220,16 @@ class CAMToolControllersHandler(BaseHandler):
                 result += f"  Spindle Speed: {controller.SpindleSpeed} RPM\n"
             if hasattr(controller, 'SpindleDir'):
                 result += f"  Spindle Direction: {controller.SpindleDir}\n"
-            if hasattr(controller, 'HorizFeed'):
-                result += f"  Horizontal Feed: {controller.HorizFeed} mm/min\n"
-            if hasattr(controller, 'VertFeed'):
-                result += f"  Vertical Feed: {controller.VertFeed} mm/min\n"
-            if hasattr(controller, 'HorizRapid'):
-                result += f"  Horizontal Rapid: {controller.HorizRapid} mm/min\n"
-            if hasattr(controller, 'VertRapid'):
-                result += f"  Vertical Rapid: {controller.VertRapid} mm/min\n"
+            # Feed/rapid properties are velocity Quantities in mm/s; convert to
+            # mm/min exactly so the value matches the displayed unit label.
+            for prop, label in (("HorizFeed", "Horizontal Feed"),
+                                ("VertFeed", "Vertical Feed"),
+                                ("HorizRapid", "Horizontal Rapid"),
+                                ("VertRapid", "Vertical Rapid")):
+                if hasattr(controller, prop):
+                    v = self.feed_to_mm_min(getattr(controller, prop))
+                    result += (f"  {label}: {v:.0f} mm/min\n" if v is not None
+                               else f"  {label}: N/A\n")
 
             return self.log_and_return("get_tool_controller", args, result=result, duration=time.time() - start_time)
 

--- a/AICopilot/handlers/cam_tool_controllers.py
+++ b/AICopilot/handlers/cam_tool_controllers.py
@@ -280,7 +280,7 @@ class CAMToolControllersHandler(BaseHandler):
             updates = []
 
             if 'spindle_speed' in args:
-                controller.SpindleSpeed = args['spindle_speed']
+                controller.SpindleSpeed = float(args['spindle_speed'])  # coerce, like the add path
                 updates.append(f"spindle_speed: {args['spindle_speed']} RPM")
 
             if 'feed_rate' in args:

--- a/AICopilot/handlers/cam_tools.py
+++ b/AICopilot/handlers/cam_tools.py
@@ -37,7 +37,8 @@ class CAMToolsHandler(BaseHandler):
                 return "Error: Path.Tool module not available. Requires FreeCAD 1.2+"
 
             name = args.get('name', '')
-            tool_type = args.get('tool_type', 'endmill')
+            # `or 'endmill'` so an explicit None doesn't crash on .lower() below.
+            tool_type = args.get('tool_type') or 'endmill'
             diameter = args.get('diameter', 6.0)
             flute_length = args.get('flute_length', None)
             shank_diameter = args.get('shank_diameter', None)

--- a/AICopilot/handlers/cam_tools.py
+++ b/AICopilot/handlers/cam_tools.py
@@ -61,7 +61,11 @@ class CAMToolsHandler(BaseHandler):
                 'slittingsaw': 'slittingsaw',
                 'reamer': 'reamer',
                 'tap': 'tap',
-                'threadmill': 'threadmill'
+                'threadmill': 'threadmill',
+                # Shipped FC 1.2 shapes the map previously rejected; stem == the
+                # shipped <name>.fcstd file, matching the working 'endmill' entry.
+                'radius': 'radius',
+                'taperedballnose': 'taperedballnose',
             }
 
             shape_id = shape_map.get(tool_type.lower())
@@ -188,6 +192,14 @@ class CAMToolsHandler(BaseHandler):
                 result += f"  Number of Flutes: {tool.Flutes}\n"
             if hasattr(tool, 'Length'):
                 result += f"  Total Length: {tool.Length}\n"
+            # Material + shape-specific geometry (present only on certain bit
+            # shapes); emit whichever exist instead of dropping them silently.
+            for prop, label in (("Material", "Material"), ("TipAngle", "Tip Angle"),
+                                ("CuttingEdgeAngle", "Cutting Edge Angle"),
+                                ("FlatRadius", "Flat Radius"), ("CornerRadius", "Corner Radius"),
+                                ("NeckDiameter", "Neck Diameter"), ("NeckLength", "Neck Length")):
+                if hasattr(tool, prop):
+                    result += f"  {label}: {getattr(tool, prop)}\n"
 
             return self.log_and_return("get_tool", args, result=result, duration=time.time() - start_time)
 
@@ -243,8 +255,12 @@ class CAMToolsHandler(BaseHandler):
                 tool.Flutes = args['number_of_flutes']
                 updates.append(f"flutes: {args['number_of_flutes']}")
 
+            if 'material' in args:
+                tool.Material = args['material']
+                updates.append(f"material: {args['material']}")
+
             if not updates:
-                error = Exception("No parameters to update. Provide diameter, flute_length, shank_diameter, or number_of_flutes.")
+                error = Exception("No parameters to update. Provide diameter, flute_length, shank_diameter, number_of_flutes, or material.")
                 return self.log_and_return("update_tool", args, error=error, duration=time.time() - start_time)
 
             self.recompute(doc)

--- a/AICopilot/handlers/cam_tools.py
+++ b/AICopilot/handlers/cam_tools.py
@@ -77,11 +77,13 @@ class CAMToolsHandler(BaseHandler):
             parameters = {
                 "Diameter": {"type": "Length", "value": f"{diameter} mm"},
             }
-            if flute_length:
+            # `is not None`, not truthiness: a legitimately-supplied 0 must not be
+            # silently dropped from the tool definition.
+            if flute_length is not None:
                 parameters["CuttingEdgeHeight"] = {"type": "Length", "value": f"{flute_length} mm"}
-            if shank_diameter:
+            if shank_diameter is not None:
                 parameters["ShankDiameter"] = {"type": "Length", "value": f"{shank_diameter} mm"}
-            if number_of_flutes:
+            if number_of_flutes is not None:
                 parameters["Flutes"] = {"type": "Integer", "value": number_of_flutes}
             if material:
                 parameters["Material"] = {"type": "String", "value": material}

--- a/AICopilot/handlers/document_ops.py
+++ b/AICopilot/handlers/document_ops.py
@@ -99,30 +99,27 @@ class DocumentOpsHandler(BaseHandler):
             if not doc:
                 return "No active document"
 
-            limit = min(args.get('limit', 100), 500)  # Cap at 500
-            offset = args.get('offset', 0)
+            # Clamp pagination args. limit is a maximum: 0 legitimately means
+            # "count only" (returns no objects), negative collapses to 0 — but it
+            # must never become a negative slice bound. offset cannot be negative
+            # (a negative offset would otherwise skip from the end of the list).
+            raw_limit = args.get('limit', 100)
+            limit = max(0, min(int(100 if raw_limit is None else raw_limit), 500))
+            raw_offset = args.get('offset', 0)
+            offset = max(0, int(0 if raw_offset is None else raw_offset))
             type_filter = args.get('type_filter', None)
 
             total_count = len(doc.Objects)
+            # Objects matching the filter — this (not total_count) is what drives
+            # pagination, so the caller can compute pages and detect truncation.
+            matching = [obj for obj in doc.Objects
+                        if not (type_filter and type_filter not in obj.TypeId)]
+            filtered_total = len(matching)
+            page = matching[offset:offset + limit]
 
             objects = []
-            count = 0
-            skipped = 0
-
-            for obj in doc.Objects:
-                # Apply type filter if specified
-                if type_filter and type_filter not in obj.TypeId:
-                    continue
-
-                # Handle offset
-                if skipped < offset:
-                    skipped += 1
-                    continue
-
-                # Stop if we've reached the limit
-                if count >= limit:
-                    break
-
+            skipped_errors = 0
+            for obj in page:
                 # Safely access properties - some FeaturePython objects
                 # can trigger GUI updates when accessing Label
                 try:
@@ -138,20 +135,25 @@ class DocumentOpsHandler(BaseHandler):
                     try:
                         obj_info["property_count"] = len(obj.PropertiesList)
                     except Exception:
-                        pass
+                        obj_info["property_count"] = None
                     objects.append(obj_info)
-                    count += 1
                 except Exception as e:
+                    skipped_errors += 1
                     FreeCAD.Console.PrintWarning(f"[MCP] Skipping object during list_objects: {e}\n")
                     continue
 
             result = {
-                "total": total_count,
+                "total": total_count,            # objects in the document
+                "filtered_total": filtered_total,  # objects matching type_filter
                 "returned": len(objects),
                 "offset": offset,
                 "limit": limit,
+                # True when more matching objects exist beyond this page.
+                "has_more": offset + len(page) < filtered_total,
                 "objects": objects
             }
+            if skipped_errors:
+                result["skipped_errors"] = skipped_errors
 
             return json.dumps(result)
 

--- a/AICopilot/handlers/document_ops.py
+++ b/AICopilot/handlers/document_ops.py
@@ -136,6 +136,24 @@ class DocumentOpsHandler(BaseHandler):
                         obj_info["property_count"] = len(obj.PropertiesList)
                     except Exception:
                         obj_info["property_count"] = None
+                    # Visibility (ViewObject is None in headless mode), recompute
+                    # State (carries 'Invalid'/'Touched' flags), and the dependency
+                    # graph (InList/OutList — the deletion-safety edges). Each is
+                    # guarded and set to null when unavailable rather than omitted.
+                    try:
+                        obj_info["visible"] = bool(obj.ViewObject.Visibility)
+                    except Exception:
+                        obj_info["visible"] = None
+                    try:
+                        obj_info["state"] = list(obj.State)
+                    except Exception:
+                        obj_info["state"] = None
+                    try:
+                        obj_info["in_list"] = [o.Name for o in obj.InList]
+                        obj_info["out_list"] = [o.Name for o in obj.OutList]
+                    except Exception:
+                        obj_info["in_list"] = None
+                        obj_info["out_list"] = None
                     objects.append(obj_info)
                 except Exception as e:
                     skipped_errors += 1

--- a/AICopilot/handlers/draft_ops.py
+++ b/AICopilot/handlers/draft_ops.py
@@ -175,6 +175,8 @@ class DraftOpsHandler(BaseHandler):
         """
         try:
             string = args.get('string', 'Text')
+            if not str(string).strip():
+                return "Error: shape_string requires a non-empty string"
             font_file = args.get('font_file', '')
             size = float(args.get('size', 10.0))
             tracking = float(args.get('tracking', 0))

--- a/AICopilot/handlers/inspector_ops.py
+++ b/AICopilot/handlers/inspector_ops.py
@@ -90,7 +90,8 @@ class InspectorOpsHandler(BaseHandler):
             profile_params   — dict of parameter overrides for process rules
             objects          — list of object names to check; default = all in doc
             doc_name         — document name; default = active document
-            include_model    — bool, default True: always run model validity+robustness
+        (model validity + robustness checks always run; process rules are added
+         only when profile_process is supplied.)
 
         Returns JSON:
             {
@@ -157,6 +158,20 @@ class InspectorOpsHandler(BaseHandler):
 
         # Build rule list — always include model rules; add process rules if profile given
         rules = _default_rules(profile)
+
+        # An unrecognized profile_process silently contributes ZERO process rules
+        # (the runner has no branch for it), so the DRC would quietly skip every
+        # process check while still reporting success. Detect that by comparing
+        # against the model-only rule set — behaviour-based, so it stays correct
+        # if the supported-process list changes upstream.
+        if profile is not None and len(rules) <= len(_default_rules(None)):
+            return json.dumps({
+                "error": (
+                    f"Unknown profile_process {process!r}: it adds no process-specific "
+                    f"rules, so only model checks would run. Use a supported process "
+                    f"(e.g. laser, resin, cnc_3axis) or omit profile_process."
+                )
+            })
 
         # Run
         result = run_drc(objects=objects, doc=doc, profile=profile, rules=rules)

--- a/AICopilot/handlers/macro_ops.py
+++ b/AICopilot/handlers/macro_ops.py
@@ -283,8 +283,9 @@ class MacroOpsHandler(BaseHandler):
         except ImportError:
             pass
 
-        old_stdout = sys.stdout
+        old_stdout, old_stderr = sys.stdout, sys.stderr
         sys.stdout = captured = io.StringIO()
+        sys.stderr = captured_err = io.StringIO()  # macro warnings/errors were dropped
         try:
             try:
                 code_obj = compile(source, path, "exec")
@@ -303,14 +304,19 @@ class MacroOpsHandler(BaseHandler):
                 })
         finally:
             sys.stdout = old_stdout
+            sys.stderr = old_stderr
 
         stdout_text = captured.getvalue().rstrip("\n")
+        stderr_text = captured_err.getvalue().rstrip("\n")
         result_value = namespace.get("result")
         result_repr = repr(result_value) if result_value is not None else ""
 
-        return json.dumps({
+        out = {
             "name": os.path.basename(path),
             "path": path,
             "stdout": stdout_text,
             "result": result_repr,
-        })
+        }
+        if stderr_text:
+            out["stderr"] = stderr_text
+        return json.dumps(out)

--- a/AICopilot/handlers/measurement_ops.py
+++ b/AICopilot/handlers/measurement_ops.py
@@ -32,13 +32,15 @@ class MeasurementOpsHandler(BaseHandler):
             if not obj2:
                 return f"Object not found: {object2}"
 
-            # Calculate distance between centers of mass
+            # Minimum surface-to-surface distance — NOT centroid distance, which
+            # reports a positive value for touching/overlapping parts. distToShape
+            # returns [dist, points, geom_info]; dist == 0 means touching/overlap.
             if hasattr(obj1, 'Shape') and hasattr(obj2, 'Shape'):
-                center1 = obj1.Shape.CenterOfMass
-                center2 = obj2.Shape.CenterOfMass
-                distance = center1.distanceToPoint(center2)
-
-                return f"Distance between {object1} and {object2}: {distance:.2f} mm"
+                distance = obj1.Shape.distToShape(obj2.Shape)[0]
+                if distance < 1e-7:
+                    return (f"Distance between {object1} and {object2}: "
+                            f"{distance:.4f} mm (touching or overlapping)")
+                return f"Distance between {object1} and {object2}: {distance:.3f} mm"
             else:
                 return "Objects must have Shape property for distance measurement"
 

--- a/AICopilot/handlers/part_ops.py
+++ b/AICopilot/handlers/part_ops.py
@@ -13,7 +13,9 @@ class PartOpsHandler(BaseHandler):
         try:
             profile_sketch = args.get('profile_sketch', '')
             height = args.get('height', 10)
-            direction = args.get('direction', 'z')
+            # Normalize case — 'X'/'Y'/'Z' must not silently fall through to Z
+            # (revolve already lowercases; extrude didn't).
+            direction = str(args.get('direction', 'z')).lower()
 
             doc = self.get_document()
             if not doc:
@@ -28,8 +30,10 @@ class PartOpsHandler(BaseHandler):
                 vec = FreeCAD.Vector(height, 0, 0)
             elif direction == 'y':
                 vec = FreeCAD.Vector(0, height, 0)
-            else:
+            elif direction == 'z':
                 vec = FreeCAD.Vector(0, 0, height)
+            else:
+                return f"Invalid direction {direction!r}; use 'x', 'y', or 'z'"
 
             if hasattr(sketch, 'Shape'):
                 shape = sketch.Shape

--- a/AICopilot/handlers/part_ops.py
+++ b/AICopilot/handlers/part_ops.py
@@ -159,6 +159,10 @@ class PartOpsHandler(BaseHandler):
         try:
             object_name = args.get('object_name', '')
             scale_factor = args.get('scale_factor', 1.5)
+            # Guard non-positive factors: <=0 inverts/zeroes the non-parametric
+            # transformGeometry path (parametric paths get clamped by FreeCAD).
+            if scale_factor <= 0:
+                return f"scale_factor must be > 0 (got {scale_factor})"
 
             doc = self.get_document()
             if not doc:

--- a/AICopilot/handlers/partdesign_ops.py
+++ b/AICopilot/handlers/partdesign_ops.py
@@ -260,7 +260,10 @@ class PartDesignOpsHandler(BaseHandler):
             else:
                 fillet = doc.addObject("Part::Fillet", name)
                 fillet.Base = obj
-                edge_list = [(edge_idx, radius, radius) for edge_idx in edges]
+                # Bounds-check like _create_fillet_with_selection — an out-of-range
+                # index otherwise produces a cryptic OCCT recompute error.
+                n_edges = len(obj.Shape.Edges) if hasattr(obj, 'Shape') else 0
+                edge_list = [(idx, radius, radius) for idx in edges if 1 <= idx <= n_edges]
                 fillet.Edges = edge_list
 
             self.recompute(doc)
@@ -399,16 +402,21 @@ class PartDesignOpsHandler(BaseHandler):
             if not obj:
                 return f"Object not found: {object_name}"
 
+            # Guard before touching obj.Shape.Edges so a shapeless object gets a
+            # clear message, not an AttributeError from the success line below —
+            # mirrors _create_fillet_auto. (Without this, zero-edge objects also
+            # report a false "all 0 edges" success.)
+            if not hasattr(obj, 'Shape') or not obj.Shape.Edges:
+                return f"Object {object_name} has no edges to chamfer"
+            n_edges = len(obj.Shape.Edges)
+
             chamfer = doc.addObject("Part::Chamfer", name)
             chamfer.Base = obj
-
-            if hasattr(obj, 'Shape') and obj.Shape.Edges:
-                edge_list = [(i + 1, distance) for i in range(len(obj.Shape.Edges))]
-                chamfer.Edges = edge_list
+            chamfer.Edges = [(i + 1, distance) for i in range(n_edges)]
 
             self.recompute(doc)
 
-            return f"Created chamfer: {chamfer.Name} on all {len(obj.Shape.Edges)} edges with distance {distance}mm"
+            return f"Created chamfer: {chamfer.Name} on all {n_edges} edges with distance {distance}mm"
 
         except Exception as e:
             return f"Error creating auto chamfer: {e}"

--- a/AICopilot/handlers/partdesign_ops.py
+++ b/AICopilot/handlers/partdesign_ops.py
@@ -538,6 +538,8 @@ class PartDesignOpsHandler(BaseHandler):
             if not feature:
                 return f"Feature not found: {feature_name}"
 
+            if count < 1:
+                return f"count must be >= 1 (got {count})"
             angle_step = angle / count
 
             axis_vector = FreeCAD.Vector(0, 0, 1)

--- a/AICopilot/handlers/partdesign_ops.py
+++ b/AICopilot/handlers/partdesign_ops.py
@@ -285,16 +285,19 @@ class PartDesignOpsHandler(BaseHandler):
             if not obj:
                 return f"Object not found: {object_name}"
 
+            # Guard before touching obj.Shape.Edges so a shapeless object gets a
+            # clear message, not an AttributeError from the success-line below.
+            if not hasattr(obj, 'Shape') or not obj.Shape.Edges:
+                return f"Object {object_name} has no edges to fillet"
+            n_edges = len(obj.Shape.Edges)
+
             fillet = doc.addObject("Part::Fillet", name)
             fillet.Base = obj
-
-            if hasattr(obj, 'Shape') and obj.Shape.Edges:
-                edge_list = [(i + 1, radius, radius) for i in range(len(obj.Shape.Edges))]
-                fillet.Edges = edge_list
+            fillet.Edges = [(i + 1, radius, radius) for i in range(n_edges)]
 
             self.recompute(doc)
 
-            return f"Created fillet: {fillet.Name} on all {len(obj.Shape.Edges)} edges with radius {radius}mm"
+            return f"Created fillet: {fillet.Name} on all {n_edges} edges with radius {radius}mm"
 
         except Exception as e:
             return f"Error creating auto fillet: {e}"
@@ -1121,8 +1124,18 @@ class PartDesignOpsHandler(BaseHandler):
             sketch_name = args.get('sketch_name', '')
             axis = args.get('axis', 'z')
             pitch = args.get('pitch', 2)
-            height = args.get('height', 10)
-            turns = args.get('turns', 5)
+            height = args.get('height')
+            turns = args.get('turns')
+            # A helix is pitch + (turns OR height). turns was read but never used,
+            # so height ignored it and the success message lied. If turns is given,
+            # it drives the height (height = pitch * turns); otherwise derive turns
+            # from height so the reported value is real.
+            if turns is not None:
+                height = pitch * turns
+            else:
+                if height is None:
+                    height = 10
+                turns = round(height / pitch, 2) if pitch else 0
             left_handed = args.get('left_handed', False)
             name = args.get('name', 'Helix')
 

--- a/AICopilot/handlers/partdesign_ops.py
+++ b/AICopilot/handlers/partdesign_ops.py
@@ -657,10 +657,12 @@ class PartDesignOpsHandler(BaseHandler):
             groove.Profile = sketch
             groove.Angle = angle
 
+            # Map the requested revolution axis to the sketch's local axes:
+            #   x -> H_Axis (horizontal), y -> V_Axis (vertical), z -> N_Axis (normal).
             if axis.lower() == 'x':
-                groove.ReferenceAxis = (sketch, ['N_Axis'])
+                groove.ReferenceAxis = (sketch, ['H_Axis'])
             elif axis.lower() == 'y':
-                groove.ReferenceAxis = (sketch, ['N_Axis'])
+                groove.ReferenceAxis = (sketch, ['V_Axis'])
             else:
                 groove.ReferenceAxis = (sketch, ['N_Axis'])
 

--- a/AICopilot/handlers/partdesign_ops.py
+++ b/AICopilot/handlers/partdesign_ops.py
@@ -999,11 +999,13 @@ class PartDesignOpsHandler(BaseHandler):
             shell.Join = 2
 
             if hasattr(obj, 'Shape') and obj.Shape.Faces:
-                faces_to_remove = []
-                for face_idx in face_indices:
-                    if 1 <= face_idx <= len(obj.Shape.Faces):
-                        faces_to_remove.append(face_idx - 1)
-                shell.Faces = tuple(faces_to_remove)
+                # Part::Thickness.Faces is an App::PropertyLinkSubList — it takes
+                # (object, ("Face1", ...)) with 1-based FaceN sub-names, NOT raw
+                # integer indices (the sibling _create_thickness_with_selection
+                # does it this way). Passing ints silently produces a wrong/closed
+                # shell.
+                valid = [fi for fi in face_indices if 1 <= fi <= len(obj.Shape.Faces)]
+                shell.Faces = (obj, tuple(f"Face{fi}" for fi in valid))
 
             self.recompute(doc)
 

--- a/AICopilot/handlers/primitives.py
+++ b/AICopilot/handlers/primitives.py
@@ -1,38 +1,41 @@
 # Primitive shape creation handlers for FreeCAD MCP
 #
 # ───────────────────────────────────────────────────────────────────────────
-# KNOWN GAP — primitives-validation
+# primitives-validation — status
 #
-# Every handler in this module reads dimensions via `args.get('length', 10)`
-# style fallbacks and passes them straight through to Part::Box / ::Cylinder
-# / etc. without validating sign, magnitude, or key spelling.  Three concrete
-# symptoms (each pinned by a test in tests/unit/test_primitives.py —
-# TestCreateBoxDegenerateDimensions, TestCreateCylinderDegenerateDimensions,
-# and the missing-key class):
+# (b) DONE: zero/negative dimensions are now rejected with the parameter name
+#     in the error (see _validate_positive and the per-handler checks). A null
+#     Part::Box/::Cylinder no longer silently lands in the document to crash a
+#     downstream OCCT Boolean. The Test*DegenerateDimensions classes in
+#     tests/unit/test_primitives.py assert the rejection.
 #
-#   1. create_box(length=0, width=0, height=0) returns "Created box (0x0x0mm)"
-#      — a null shape sits in the document and crashes downstream OCCT Booleans.
-#   2. create_box(length=-10, ...) propagates a negative dimension; FreeCAD
-#      silently clamps or produces an invalid shape.
-#   3. Missing `length` falls back to 10mm.  An LLM that types `'lenght'`
-#      gets a 10mm box silently.  This is the most common real-world hit
-#      because LLMs misspell parameter names constantly.  Pinned by
-#      test_missing_dimension_uses_default in TestCreateBoxDegenerateDimensions.
-#
-# WHEN MODIFYING THIS MODULE: grep for `TODO(primitives-validation)` to find
-# the call sites, and decide whether your change should also close the gap.
-# A proper fix would (a) reject unknown args keys with a clear error listing
-# the accepted parameters, and (b) reject zero/negative dimensions with the
-# parameter name in the error.  The Test*DegenerateDimensions classes in
-# tests/unit/test_primitives.py will fail when you do this — that's the
-# signal that you should flip them to assert the new validation behavior,
-# not silently delete them.
+# (a) STILL OPEN: unknown/misspelled arg keys ('lenght' → silent 10mm default)
+#     are NOT yet rejected. This needs the *full* injected-key envelope first:
+#     _dispatch_part_operations forwards the entire args dict (it carries
+#     `operation`, and the cyber confirm-gate can add `confirmed`, plus any
+#     async/internal `_`-prefixed keys). A naive allow-list that omits one of
+#     those would reject every primitive call. Enumerate the envelope before
+#     adding strict key validation; until then a misspelled dimension key still
+#     silently takes the default.
 # ───────────────────────────────────────────────────────────────────────────
 
 import FreeCAD
 import FreeCADGui
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from .base import BaseHandler
+
+
+def _validate_positive(prim: str, **dims) -> Optional[str]:
+    """Return an 'Error creating <prim>: ...' string if any named dimension is
+    not a number > 0; otherwise None. Names the offending parameter so the MCP
+    caller (often an LLM) can correct it."""
+    for name, val in dims.items():
+        try:
+            if float(val) <= 0:
+                return f"Error creating {prim}: {name} must be > 0 (got {val})"
+        except (TypeError, ValueError):
+            return f"Error creating {prim}: {name} must be a number (got {val!r})"
+    return None
 
 
 class PrimitivesHandler(BaseHandler):
@@ -41,8 +44,6 @@ class PrimitivesHandler(BaseHandler):
     def create_box(self, args: Dict[str, Any]) -> str:
         """Create a box with specified dimensions."""
         try:
-            # TODO(primitives-validation): no sign/key/zero check — see module
-            # header for the gap and the pinning test class to flip on fix.
             length = args.get('length', 10)
             width = args.get('width', 10)
             height = args.get('height', 10)
@@ -50,6 +51,10 @@ class PrimitivesHandler(BaseHandler):
             y = args.get('y', 0)
             z = args.get('z', 0)
             name = args.get('name', 'Box')
+
+            err = _validate_positive('box', length=length, width=width, height=height)
+            if err:
+                return err
 
             doc = self.get_document()
             if not doc:
@@ -79,6 +84,10 @@ class PrimitivesHandler(BaseHandler):
             z = args.get('z', 0)
             name = args.get('name', 'Cylinder')
 
+            err = _validate_positive('cylinder', radius=radius, height=height)
+            if err:
+                return err
+
             doc = self.get_document()
             if not doc:
                 return "Error creating cylinder: No active document. Call view_control(operation='create_document') first."
@@ -104,6 +113,10 @@ class PrimitivesHandler(BaseHandler):
             y = args.get('y', 0)
             z = args.get('z', 0)
             name = args.get('name', 'Sphere')
+
+            err = _validate_positive('sphere', radius=radius)
+            if err:
+                return err
 
             doc = self.get_document()
             if not doc:
@@ -132,6 +145,19 @@ class PrimitivesHandler(BaseHandler):
             z = args.get('z', 0)
             name = args.get('name', 'Cone')
 
+            # height must be positive; radii non-negative and not both zero —
+            # radius2=0 is a valid pointed cone, radius1==radius2 a valid cylinder.
+            err = _validate_positive('cone', height=height)
+            if err:
+                return err
+            try:
+                if float(radius1) < 0 or float(radius2) < 0:
+                    return f"Error creating cone: radii must be >= 0 (got R1={radius1}, R2={radius2})"
+                if float(radius1) == 0 and float(radius2) == 0:
+                    return "Error creating cone: at least one of radius1/radius2 must be > 0"
+            except (TypeError, ValueError):
+                return f"Error creating cone: radii must be numbers (got R1={radius1!r}, R2={radius2!r})"
+
             doc = self.get_document()
             if not doc:
                 return "Error creating cone: No active document. Call view_control(operation='create_document') first."
@@ -159,6 +185,10 @@ class PrimitivesHandler(BaseHandler):
             y = args.get('y', 0)
             z = args.get('z', 0)
             name = args.get('name', 'Torus')
+
+            err = _validate_positive('torus', radius1=radius1, radius2=radius2)
+            if err:
+                return err
 
             doc = self.get_document()
             if not doc:

--- a/AICopilot/handlers/sketch_ops.py
+++ b/AICopilot/handlers/sketch_ops.py
@@ -598,8 +598,16 @@ class SketchOpsHandler(BaseHandler):
             p2 = args.get('pos_id2', 0)
             value = args.get('value', None)
 
-            # Build constraint based on type
-            ct = constraint_type
+            # Build constraint based on type. Normalize case against the canonical
+            # vocabulary (single source of truth) so 'horizontal' / 'DISTANCEX'
+            # resolve instead of silently falling through to "Unknown" — the
+            # case-sensitive compares below are otherwise a syntactic seam.
+            _CANON = {n.lower(): n for n in (
+                'Horizontal', 'Vertical', 'Block', 'Perpendicular', 'Parallel',
+                'Tangent', 'Equal', 'Coincident', 'PointOnObject', 'Fix',
+                'Symmetric', 'Radius', 'Diameter', 'Distance', 'DistanceX',
+                'DistanceY', 'Angle')}
+            ct = _CANON.get(str(constraint_type).lower(), constraint_type)
 
             # --- Single-geometry, no value ---
             if ct in ('Horizontal', 'Vertical', 'Block'):

--- a/AICopilot/handlers/sketch_ops.py
+++ b/AICopilot/handlers/sketch_ops.py
@@ -125,15 +125,17 @@ class SketchOpsHandler(BaseHandler):
             else:
                 results.append("Over-constrained or conflicting constraints")
 
-            # Check for open wires
+            # Check for open wires.
+            # closed_wires/open_wires must be bound before the verdict logic below,
+            # which references them even when the sketch produced no Shape.
+            closed_wires = 0
+            open_wires = 0
             if hasattr(sketch, 'Shape') and sketch.Shape:
                 shape = sketch.Shape
                 wire_count = len(shape.Wires)
                 results.append(f"Wires: {wire_count}")
 
                 # Check if wires are closed
-                closed_wires = 0
-                open_wires = 0
                 for wire in shape.Wires:
                     if wire.isClosed():
                         closed_wires += 1
@@ -459,25 +461,30 @@ class SketchOpsHandler(BaseHandler):
             cx1 = x - half_len
             cx2 = x + half_len
 
-            # Top line: left to right
+            # Slot outline as one counter-clockwise loop so both end caps bulge
+            # OUTWARD. FreeCAD's ArcOfCircle sweeps CCW (increasing angle) from the
+            # first parameter to the second, so the start/end angles below keep each
+            # arc on the outer side; endpoints chain via the Coincident(gA,2,gB,1)
+            # constraints added afterwards.
+            # Bottom line: left to right
             g0 = sketch.addGeometry(Part.LineSegment(
-                FreeCAD.Vector(cx1, y + r, 0),
-                FreeCAD.Vector(cx2, y + r, 0)
+                FreeCAD.Vector(cx1, y - r, 0),
+                FreeCAD.Vector(cx2, y - r, 0)
             ))
-            # Right arc: 90° to -90° (top to bottom)
+            # Right arc: -90° to 90° (bottom to top, bulging right/outward)
             g1 = sketch.addGeometry(Part.ArcOfCircle(
                 Part.Circle(FreeCAD.Vector(cx2, y, 0), FreeCAD.Vector(0, 0, 1), r),
-                math.radians(90), math.radians(-90)
+                math.radians(-90), math.radians(90)
             ))
-            # Bottom line: right to left
+            # Top line: right to left
             g2 = sketch.addGeometry(Part.LineSegment(
-                FreeCAD.Vector(cx2, y - r, 0),
-                FreeCAD.Vector(cx1, y - r, 0)
+                FreeCAD.Vector(cx2, y + r, 0),
+                FreeCAD.Vector(cx1, y + r, 0)
             ))
-            # Left arc: -90° to 90° (bottom to top)
+            # Left arc: 90° to 270° (top to bottom, bulging left/outward)
             g3 = sketch.addGeometry(Part.ArcOfCircle(
                 Part.Circle(FreeCAD.Vector(cx1, y, 0), FreeCAD.Vector(0, 0, 1), r),
-                math.radians(-90), math.radians(90)
+                math.radians(90), math.radians(270)
             ))
 
             # Coincident constraints to close the shape

--- a/AICopilot/handlers/spatial_ops.py
+++ b/AICopilot/handlers/spatial_ops.py
@@ -153,7 +153,10 @@ class SpatialOpsHandler(BaseHandler):
             lines = [f"Clearance: {n1} vs {n2}"]
             lines.append(f"  Minimum distance: {min_dist:.4f} mm")
 
-            if min_dist < _VOL_TOL:
+            # Touching is a LINEAR condition — compare against the linear OCCT
+            # tolerance, not _VOL_TOL (1e-9 mm³), which as a distance threshold is
+            # far tighter than OCCT's own resolution and misreports contact as a gap.
+            if min_dist < _OCCT_LIN_TOL:
                 lines.append(f"  Status: TOUCHING (zero clearance)")
             else:
                 lines.append(f"  Status: {min_dist:.4f} mm gap")
@@ -170,7 +173,7 @@ class SpatialOpsHandler(BaseHandler):
                     lines.append(f"    ... and {len(point_pairs) - 4} more")
 
             # Determine dominant gap direction from first pair
-            if point_pairs and min_dist > _VOL_TOL:
+            if point_pairs and min_dist > _OCCT_LIN_TOL:
                 p1, p2 = point_pairs[0]
                 dx = abs(p2.x - p1.x)
                 dy = abs(p2.y - p1.y)

--- a/AICopilot/handlers/spatial_ops.py
+++ b/AICopilot/handlers/spatial_ops.py
@@ -9,6 +9,7 @@
 
 import json
 import math
+import re
 import FreeCAD
 from typing import Dict, Any, List, Tuple
 from .base import BaseHandler
@@ -260,10 +261,18 @@ class SpatialOpsHandler(BaseHandler):
             if not face1_id or not face2_id:
                 return "Both face1 and face2 are required (e.g., 'Face1', 'Face6')"
 
-            # Extract face index from "FaceN" string
+            # Extract face index from an anchored "FaceN" string — the old
+            # replace('Face','') turned 'Face1Face2' into '12' and silently
+            # accessed the wrong face.
+            def _face_idx(fid):
+                m = re.match(r'^\s*Face(\d+)\s*$', fid, re.IGNORECASE)
+                return int(m.group(1)) - 1 if m else None
             try:
-                idx1 = int(face1_id.replace('Face', '')) - 1
-                idx2 = int(face2_id.replace('Face', '')) - 1
+                idx1 = _face_idx(face1_id)
+                idx2 = _face_idx(face2_id)
+                if idx1 is None or idx2 is None:
+                    return (f"Invalid face id; expected 'FaceN' "
+                            f"(got {face1_id!r}, {face2_id!r})")
                 f1 = s1.Faces[idx1]
                 f2 = s2.Faces[idx2]
             except (ValueError, IndexError) as e:

--- a/AICopilot/handlers/spatial_ops.py
+++ b/AICopilot/handlers/spatial_ops.py
@@ -361,6 +361,7 @@ class SpatialOpsHandler(BaseHandler):
             names = list(shapes.keys())
             collisions = []
             clear_pairs = 0
+            failed_pairs = []  # pairs where the geometry op raised — never silently "clear"
 
             for i in range(len(names)):
                 for j in range(i + 1, len(names)):
@@ -369,8 +370,14 @@ class SpatialOpsHandler(BaseHandler):
                     if not shapes[n1].BoundBox.intersect(shapes[n2].BoundBox):
                         clear_pairs += 1
                         continue
-                    common = shapes[n1].common(shapes[n2])
-                    vol = common.Volume
+                    # common() can raise on degenerate geometry — wrap per-pair so
+                    # one bad pair doesn't abort the whole batch.
+                    try:
+                        common = shapes[n1].common(shapes[n2])
+                        vol = common.Volume
+                    except Exception:
+                        failed_pairs.append((n1, n2))
+                        continue
                     if vol > _VOL_TOL:
                         collisions.append((n1, n2, vol))
                     else:
@@ -383,13 +390,19 @@ class SpatialOpsHandler(BaseHandler):
                             else:
                                 clear_pairs += 1
                         except Exception:
-                            clear_pairs += 1
+                            # A distToShape failure is NOT a clear pair — count it
+                            # as failed so collisions+clear+failed == total_pairs.
+                            failed_pairs.append((n1, n2))
 
             total_pairs = len(names) * (len(names) - 1) // 2
             lines = [f"Batch interference: {len(names)} objects, {total_pairs} pairs checked"]
             lines.extend(warnings)
             lines.append(f"  Collisions: {len(collisions)}")
             lines.append(f"  Clear: {clear_pairs}")
+            if failed_pairs:
+                lines.append(f"  Failed (geometry error): {len(failed_pairs)}")
+                for n1, n2 in failed_pairs:
+                    lines.append(f"    {n1} ↔ {n2}: interference check errored")
 
             if collisions:
                 lines.append(f"  Colliding pairs:")

--- a/AICopilot/handlers/spreadsheet_ops.py
+++ b/AICopilot/handlers/spreadsheet_ops.py
@@ -52,7 +52,8 @@ class SpreadsheetOpsHandler(BaseHandler):
             if spreadsheet.TypeId != 'Spreadsheet::Sheet':
                 return f"Object {spreadsheet_name} is not a spreadsheet"
 
-            spreadsheet.set(cell, str(value))
+            # A null value clears the cell rather than writing the literal "None".
+            spreadsheet.set(cell, '' if value is None else str(value))
             self.recompute(doc)
 
             return f"Set {spreadsheet_name}.{cell} = {value}"

--- a/AICopilot/handlers/spreadsheet_ops.py
+++ b/AICopilot/handlers/spreadsheet_ops.py
@@ -78,8 +78,21 @@ class SpreadsheetOpsHandler(BaseHandler):
                 return f"Object {spreadsheet_name} is not a spreadsheet"
 
             value = spreadsheet.get(cell)
+            # getContents returns the stored expression/formula (e.g. "=A1+B1");
+            # spreadsheet.get() evaluates it away. Surface both so a read→write
+            # round-trip doesn't silently replace a live formula with a literal,
+            # and emit JSON null (not the string "None") for an empty cell.
+            try:
+                formula = spreadsheet.getContents(cell)
+            except Exception:
+                formula = None
 
-            return json.dumps({"cell": cell, "value": str(value)})
+            return json.dumps({
+                "cell": cell,
+                "value": None if value is None else str(value),
+                "type": type(value).__name__ if value is not None else None,
+                "formula": formula,
+            })
 
         except Exception as e:
             return f"Error getting cell: {e}"
@@ -354,33 +367,22 @@ class SpreadsheetOpsHandler(BaseHandler):
                 except Exception:
                     pass
 
-            # Alternative method using getAlias on known cells
-            # Scan full sheet dimensions if XML parsing fails.
-            # Ask the spreadsheet for its own row/column count; fall back to
-            # a large-but-finite ceiling so the loop terminates even if the
-            # spreadsheet API is unavailable.
-            if not aliases:
-                import string
+            # Fallback if XML parsing yielded nothing: ask the sheet for its
+            # non-empty cells and check each for an alias. getUsedCells() covers
+            # the exact populated extent regardless of column — far better than
+            # scanning a guessed A-Z grid (which silently missed columns past Z).
+            if not aliases and callable(getattr(spreadsheet, 'getUsedCells', None)):
                 try:
-                    max_row = spreadsheet.rows() if callable(getattr(spreadsheet, 'rows', None)) else 10000
-                    max_col = spreadsheet.columns() if callable(getattr(spreadsheet, 'columns', None)) else 26
+                    used_cells = list(spreadsheet.getUsedCells())
                 except Exception:
-                    max_row, max_col = 10000, 26
-                cols = list(string.ascii_uppercase[:max_col])
-                last_hit_row = 0
-                for row in range(1, max_row + 1):
-                    # Stop scanning if no alias found in 50 consecutive rows
-                    if row > last_hit_row + 50 and row > 1:
-                        break
-                    for col in cols:
-                        cell = f"{col}{row}"
-                        try:
-                            alias = spreadsheet.getAlias(cell)
-                            if alias:
-                                aliases[cell] = alias
-                                last_hit_row = row
-                        except Exception:
-                            pass
+                    used_cells = []
+                for cell in used_cells:
+                    try:
+                        alias = spreadsheet.getAlias(cell)
+                        if alias:
+                            aliases[cell] = alias
+                    except Exception:
+                        pass
 
             return json.dumps({
                 "spreadsheet": spreadsheet_name,
@@ -436,15 +438,18 @@ class SpreadsheetOpsHandler(BaseHandler):
 
             start_col_num = col_to_num(start_col)
 
-            lines = csv_data.strip().split('\n')
+            # csv.reader handles quoted fields, embedded delimiters and embedded
+            # newlines correctly; naive line.split(delimiter) silently breaks cell
+            # boundaries whenever a field contains the delimiter or a newline.
+            import csv as _csv
+            import io as _io
             cells_set = 0
-
-            for row_idx, line in enumerate(lines):
-                values = line.split(delimiter)
+            reader = _csv.reader(_io.StringIO(csv_data), delimiter=delimiter)
+            for row_idx, values in enumerate(reader):
                 for col_idx, value in enumerate(values):
                     col_letter = num_to_col(start_col_num + col_idx)
                     cell = f"{col_letter}{start_row + row_idx}"
-                    spreadsheet.set(cell, value.strip())
+                    spreadsheet.set(cell, value)
                     cells_set += 1
 
             self.recompute(doc)
@@ -459,7 +464,7 @@ class SpreadsheetOpsHandler(BaseHandler):
         try:
             spreadsheet_name = args.get('spreadsheet_name', '')
             start_cell = args.get('start_cell', 'A1')
-            end_cell = args.get('end_cell', 'J100')
+            end_cell = args.get('end_cell')   # None => auto-detect the used range
             delimiter = args.get('delimiter', ',')
 
             doc = self.get_document()
@@ -489,6 +494,18 @@ class SpreadsheetOpsHandler(BaseHandler):
                     num //= 26
                 return col
 
+            # Default to the sheet's actual used range, not a hardcoded J100 box
+            # that silently drops any data beyond column J / row 100.
+            if not end_cell:
+                end_cell = 'J100'
+                try:
+                    if callable(getattr(spreadsheet, 'getUsedRange', None)):
+                        ur = spreadsheet.getUsedRange()
+                        if ur and len(ur) == 2 and ur[1]:
+                            end_cell = ur[1]
+                except Exception:
+                    pass
+
             match_start = re.match(r'([A-Z]+)(\d+)', start_cell.upper())
             match_end = re.match(r'([A-Z]+)(\d+)', end_cell.upper())
 
@@ -500,23 +517,44 @@ class SpreadsheetOpsHandler(BaseHandler):
             start_row = int(match_start.group(2))
             end_row = int(match_end.group(2))
 
-            csv_lines = []
+            # csv.writer quotes/escapes fields containing the delimiter, quotes or
+            # newlines; the old delimiter.join produced structurally broken CSV.
+            import csv as _csv
+            import io as _io
+            buf = _io.StringIO()
+            writer = _csv.writer(buf, delimiter=delimiter)
+            errors = []
             for row in range(start_row, end_row + 1):
                 row_values = []
                 for col_num in range(start_col_num, end_col_num + 1):
                     cell = f"{num_to_col(col_num)}{row}"
                     try:
                         value = spreadsheet.get(cell)
-                        row_values.append(str(value) if value is not None else "")
-                    except Exception:
+                        row_values.append("" if value is None else str(value))
+                    except Exception as e:
                         row_values.append("")
-                csv_lines.append(delimiter.join(row_values))
+                        errors.append(f"{cell}: {e}")
+                writer.writerow(row_values)
+            csv_data = buf.getvalue()
 
-            csv_data = '\n'.join(csv_lines)
+            # Flag if the sheet has populated cells beyond the exported range.
+            truncated = False
+            try:
+                if callable(getattr(spreadsheet, 'getUsedRange', None)):
+                    ur = spreadsheet.getUsedRange()
+                    if ur and len(ur) == 2 and ur[1]:
+                        m = re.match(r'([A-Z]+)(\d+)', ur[1].upper())
+                        if m and (col_to_num(m.group(1)) > end_col_num
+                                  or int(m.group(2)) > end_row):
+                            truncated = True
+            except Exception:
+                pass
 
             return json.dumps({
                 "spreadsheet": spreadsheet_name,
                 "range": f"{start_cell}:{end_cell}",
+                "truncated": truncated,
+                "errors": errors,
                 "csv": csv_data
             })
 

--- a/AICopilot/handlers/transforms.py
+++ b/AICopilot/handlers/transforms.py
@@ -100,8 +100,10 @@ class TransformsHandler(BaseHandler):
             if not obj:
                 return f"Object not found: {object_name}"
 
-            # Create copy
-            copy = doc.copyObject(obj)
+            # Create copy. with_dependencies=True so parametric/body-backed
+            # objects copy their dependency chain instead of referencing the
+            # original's (which silently couples the "copy" to the source).
+            copy = doc.copyObject(obj, True)
             copy.Label = name
             copy.Placement.Base = FreeCAD.Vector(
                 obj.Placement.Base.x + x,

--- a/AICopilot/handlers/view_ops.py
+++ b/AICopilot/handlers/view_ops.py
@@ -195,7 +195,7 @@ class ViewOpsHandler(BaseHandler):
         """Zoom in on the view."""
         try:
             if FreeCADGui.ActiveDocument:
-                FreeCADGui.activeDocument().activeView().viewAxonometric()
+                FreeCADGui.activeDocument().activeView().zoomIn()
                 return "Zoomed in"
             else:
                 return "No active document"
@@ -206,7 +206,7 @@ class ViewOpsHandler(BaseHandler):
         """Zoom out on the view."""
         try:
             if FreeCADGui.ActiveDocument:
-                FreeCADGui.activeDocument().activeView().viewAxonometric()
+                FreeCADGui.activeDocument().activeView().zoomOut()
                 return "Zoomed out"
             else:
                 return "No active document"

--- a/AICopilot/ocl_surface_op.py
+++ b/AICopilot/ocl_surface_op.py
@@ -57,6 +57,8 @@ def _load_stl(stl_file, ocl):
         if len(raw) < 4:
             raise ValueError(f"Truncated STL file: {stl_file}")
         n_tris = struct.unpack("<I", raw)[0]
+        if n_tris == 0:
+            raise ValueError(f"STL file has no triangles: {stl_file}")
 
         for _ in range(n_tris):
             f.read(12)  # normal vector (ignored — OCL recomputes)
@@ -249,6 +251,17 @@ class OCLSurfaceProxy:
         safe_z      = float(obj.SafeHeight)
         cut_feed    = float(obj.CutFeed)
         plunge_feed = float(obj.PlungeFeed)
+
+        # Guard the native-OCL inputs: zero/negative values either hang or crash
+        # the underlying C++. StepOver <= 0 makes the scan-line loop never advance
+        # (infinite loop on the GUI thread); setSampling(0) divides by zero;
+        # BallCutter(0, ...) is undefined.
+        if tool_dia <= 0:
+            raise ValueError(f"ToolDiameter must be > 0 (got {tool_dia})")
+        if stepover <= 0:
+            raise ValueError(f"StepOver must be > 0 (got {stepover})")
+        if sampling <= 0:
+            raise ValueError(f"SampleInterval must be > 0 (got {sampling})")
 
         t0 = time.time()
 

--- a/AICopilot/ocl_surface_op.py
+++ b/AICopilot/ocl_surface_op.py
@@ -224,6 +224,22 @@ class OCLSurfaceProxy:
                 f"[OCLSurface] execute() failed: {e}\n"
                 f"{traceback.format_exc()}\n"
             )
+            # A swallowed failure used to leave the previous/empty Path in place,
+            # so the recompute "succeeded" and the MCP caller saw 'done' with a
+            # stale toolpath. Clear the Path and record the error so failure is
+            # detectable. Each step is guarded so the handler itself never throws.
+            try:
+                import Path
+                obj.Path = Path.Path()
+            except Exception:
+                pass
+            try:
+                if not hasattr(obj, "ExecuteError"):
+                    obj.addProperty("App::PropertyString", "ExecuteError",
+                                    "OCL", "Last execute() error (empty = OK)")
+                obj.ExecuteError = str(e)
+            except Exception:
+                pass
 
     def _do_execute(self, obj):
         """Inner execute — raises on error so the outer handler can log it."""

--- a/freecad_crash_report.py
+++ b/freecad_crash_report.py
@@ -49,6 +49,7 @@ import glob
 import json
 import os
 import platform
+import re
 import subprocess
 import time
 import zipfile
@@ -156,10 +157,13 @@ def _find_macos_crash_report(max_age_s: int = 180) -> Optional[str]:
     if platform.system() != "Darwin":
         return None
 
+    # FreeCAD* matches both the GUI (FreeCAD-*) and headless (FreeCADCmd-*)
+    # process names. .ips is the macOS 12+ JSON format; .crash is legacy plaintext.
     patterns = [
         os.path.expanduser("~/Library/Logs/DiagnosticReports/FreeCAD*.crash"),
         os.path.expanduser("~/Library/Logs/DiagnosticReports/FreeCAD*.ips"),
         "/Library/Logs/DiagnosticReports/FreeCAD*.crash",
+        "/Library/Logs/DiagnosticReports/FreeCAD*.ips",
     ]
     candidates = []
     for pat in patterns:
@@ -180,28 +184,102 @@ def _find_macos_crash_report(max_age_s: int = 180) -> Optional[str]:
 
 
 def _parse_crash_report(content: str, path: str) -> str:
-    """Extract the signal, exception, and crashed-thread backtrace."""
-    lines = content.splitlines()
-    meta, thread0, in_thread0 = [], [], False
+    """Extract the signal, exception, and crashed-thread backtrace.
 
+    macOS 12+ writes .ips reports (a JSON header line + a JSON body); older
+    macOS wrote plaintext .crash. Detect the format and dispatch — the previous
+    plaintext-only parser produced empty output on every modern .ips.
+    """
+    if content.lstrip().startswith("{"):
+        try:
+            nl = content.index("\n")
+            header = json.loads(content[:nl])
+            body = json.loads(content[nl + 1:])
+            return _parse_ips_report(header, body, path)
+        except Exception:
+            pass  # not valid .ips JSON — fall through to legacy plaintext
+    return _parse_crash_report_legacy(content, path)
+
+
+def _parse_ips_report(header: dict, body: dict, path: str) -> str:
+    """Parse a macOS 12+ .ips (JSON) crash report into a readable summary."""
+    out = [f"[{Path(path).name}]"]
+
+    app = header.get("app_name") or body.get("procName", "?")
+    ver = header.get("app_version") or ""
+    out.append(f"Process: {app} {ver}".rstrip())
+    if header.get("os_version"):
+        out.append(f"OS: {header['os_version']}")
+
+    exc = body.get("exception") or {}
+    if exc:
+        line = f"Exception: {exc.get('type', '')}".rstrip()
+        if exc.get("signal"):
+            line += f" ({exc['signal']})"
+        out.append(line)
+        if exc.get("subtype"):
+            out.append(f"  Subtype: {exc['subtype']}")
+    term = body.get("termination") or {}
+    if term.get("indicator"):
+        out.append(f"Termination: {term['indicator']}")
+
+    images = body.get("usedImages") or []
+
+    def _image_name(idx):
+        if isinstance(idx, int) and 0 <= idx < len(images):
+            img = images[idx]
+            return img.get("name") or os.path.basename(img.get("path", "")) or f"image#{idx}"
+        return f"image#{idx}"
+
+    threads = body.get("threads") or []
+    # The crashed thread is rarely thread 0 — use faultingThread / the triggered flag.
+    crashed = body.get("faultingThread")
+    if not isinstance(crashed, int):
+        crashed = next((i for i, t in enumerate(threads) if t.get("triggered")), None)
+
+    if isinstance(crashed, int) and 0 <= crashed < len(threads):
+        frames = threads[crashed].get("frames") or []
+        out.append(f"\nCrashed thread {crashed} (first 20 of {len(frames)} frames):")
+        for n, fr in enumerate(frames[:20]):
+            name = _image_name(fr.get("imageIndex"))
+            if fr.get("symbol"):
+                out.append(f"  {n:<3} {name}  {fr['symbol']} + {fr.get('symbolLocation', 0)}")
+            else:
+                out.append(f"  {n:<3} {name} + {fr.get('imageOffset', '?')}")
+    return "\n".join(out)
+
+
+def _parse_crash_report_legacy(content: str, path: str) -> str:
+    """Parse a legacy plaintext .crash report (macOS 11 and earlier)."""
+    lines = content.splitlines()
+    meta = []
+    crashed_thread = 0
     for line in lines:
         for prefix in ("Exception Type:", "Exception Codes:", "Exception Subtype:",
                        "Termination Signal:", "Termination Reason:", "Crashed Thread:"):
             if line.startswith(prefix):
                 meta.append(line)
+                if prefix == "Crashed Thread:":
+                    m = re.search(r"Crashed Thread:\s*(\d+)", line)
+                    if m:
+                        crashed_thread = int(m.group(1))
 
-        if line.startswith("Thread 0 Crashed:") or line.startswith("Thread 0 name:"):
-            in_thread0 = True
-        if in_thread0:
-            thread0.append(line)
-            if line == "" and len(thread0) > 3:
-                break          # end of thread 0 block
+    # Collect the ACTUAL crashed thread's frames, not a hardcoded Thread 0.
+    frames = []
+    in_block = False
+    for line in lines:
+        if line.startswith(f"Thread {crashed_thread} Crashed:"):
+            in_block = True
+            continue
+        if in_block:
+            if line.strip() == "":
+                break
+            frames.append(line)
 
-    summary = f"[{Path(path).name}]\n"
-    summary += "\n".join(meta)
-    if thread0:
-        summary += "\n\nCrashed thread (first 20 frames):\n"
-        summary += "\n".join(thread0[:20])
+    summary = f"[{Path(path).name}]\n" + "\n".join(meta)
+    if frames:
+        summary += (f"\n\nCrashed thread {crashed_thread} (first 20 frames):\n"
+                    + "\n".join(frames[:20]))
     return summary
 
 

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -445,7 +445,7 @@ def _diagnose_crash(error: Exception = None) -> str:
 
 # Initialize debugging infrastructure (optional - works without it)
 try:
-    from freecad_debug import init_debugger, debug_deccorator
+    from freecad_debug import init_debugger, debug_decorator
     from freecad_health import init_monitor
     import logging
     

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -1000,7 +1000,11 @@ async def main():
                             "source_object": {"type": "string", "description": "Object name in source document"},
                             "x": {"type": "number", "description": "X placement offset (mm)", "default": 0},
                             "y": {"type": "number", "description": "Y placement offset (mm)", "default": 0},
-                            "z": {"type": "number", "description": "Z placement offset (mm)", "default": 0}
+                            "z": {"type": "number", "description": "Z placement offset (mm)", "default": 0},
+                            # list_objects pagination parameters
+                            "limit": {"type": "integer", "description": "list_objects: max objects to return (1-500, default 100)", "default": 100},
+                            "offset": {"type": "integer", "description": "list_objects: number of (filtered) objects to skip for pagination", "default": 0},
+                            "type_filter": {"type": "string", "description": "list_objects: only return objects whose TypeId contains this substring"}
                         },
                         "required": ["operation"]
                     },
@@ -2122,11 +2126,11 @@ async def main():
             status = poll_resp.get("status")
             if status == "done":
                 _complete_op()
-                return [types.TextContent(type="text", text=json.dumps({"result": poll_resp.get("result"), "elapsed": poll_resp.get("elapsed")}))]
+                return [types.TextContent(type="text", text=json.dumps({"result": poll_resp.get("result"), "elapsed": poll_resp.get("elapsed_s")}))]
             elif status == "timeout":
                 return [types.TextContent(type="text", text=json.dumps({"error": poll_resp["error"], "job_id": job_id}))]
             else:
-                return [types.TextContent(type="text", text=json.dumps({"error": poll_resp.get("error"), "elapsed": poll_resp.get("elapsed")}))]
+                return [types.TextContent(type="text", text=json.dumps({"error": poll_resp.get("error"), "error_id": poll_resp.get("error_id"), "elapsed": poll_resp.get("elapsed_s")}))]
 
         # macOS screenshot: run screencapture in the bridge process (which inherits
         # Screen Recording permission from the terminal), never touching FreeCAD's
@@ -2163,7 +2167,8 @@ async def main():
         elif name in ["partdesign_operations", "sketch_operations", "part_operations",
                       "view_control", "cam_operations", "cam_tools", "cam_tool_controllers",
                       "cam_machines", "mesh_operations", "measurement_operations",
-                      "spatial_query",
+                      "spatial_query", "geometric_verification", "fixture_operations",
+                      "run_inspector", "get_last_traceback",
                       "spreadsheet_operations", "draft_operations", "get_debug_logs",
                       "macro_operations", "api_introspection",
                       "execute_python_async", "poll_job", "list_jobs",
@@ -2204,7 +2209,7 @@ async def main():
                             _complete_op()
                             payload: dict = {
                                 "result": poll_resp.get("result"),
-                                "elapsed": poll_resp.get("elapsed"),
+                                "elapsed": poll_resp.get("elapsed_s"),
                             }
                         elif status == "timeout":
                             payload = {
@@ -2215,7 +2220,8 @@ async def main():
                             # status == "error" or unexpected
                             payload = {
                                 "error": poll_resp.get("error"),
-                                "elapsed": poll_resp.get("elapsed"),
+                                "error_id": poll_resp.get("error_id"),
+                                "elapsed": poll_resp.get("elapsed_s"),
                             }
                         if _acc.has_any("warn"):
                             payload["events"] = _acc.to_envelope("warn")

--- a/mcp_bridge_framing.py
+++ b/mcp_bridge_framing.py
@@ -13,7 +13,24 @@ Version: 2.1.2 (matches freecad_mcp_handler v2.1.2)
 
 import socket
 import struct
+import sys
 from typing import Optional
+
+# Maximum message size for the length-prefixed protocol (single source of truth
+# on the bridge side). The handler (freecad_mcp_handler.py) embeds its own copy
+# because it runs inside FreeCAD and cannot import this module — keep them equal.
+MAX_MESSAGE_SIZE = 50 * 1024  # 50KB ≈ 15K tokens
+
+
+def _log(msg: str) -> None:
+    """Log to stderr only.
+
+    This process speaks the MCP protocol over *stdout*; any stray write to
+    stdout is parsed by the client as a protocol frame and corrupts the
+    transport. All framing diagnostics must go to stderr.
+    """
+    print(msg, file=sys.stderr, flush=True)
+
 
 def send_message(sock: socket.socket, message_str: str) -> bool:
     """Send a length-prefixed message over socket (client-side).
@@ -39,19 +56,26 @@ def send_message(sock: socket.socket, message_str: str) -> bool:
         # Encode message
         message_bytes = message_str.encode('utf-8')
         message_len = len(message_bytes)
-        
+
+        # Refuse to put an oversized frame on the wire: the peer will reject the
+        # body after reading the length prefix, desyncing every subsequent frame.
+        if message_len > MAX_MESSAGE_SIZE:
+            _log(f"❌ Refusing to send oversized message: {message_len} bytes "
+                 f"(limit {MAX_MESSAGE_SIZE}); sending it would desync the framing.")
+            return False
+
         # Create length prefix (4 bytes, big-endian unsigned int)
         length_prefix = struct.pack('>I', message_len)
-        
+
         # Send length + message atomically
         sock.sendall(length_prefix + message_bytes)
         return True
-        
+
     except (socket.error, BrokenPipeError, OSError) as e:
-        print(f"⚠️  Socket send error: {e}")
+        _log(f"⚠️  Socket send error: {e}")
         return False
     except Exception as e:
-        print(f"❌ Unexpected error in send_message: {e}")
+        _log(f"❌ Unexpected error in send_message: {e}")
         return False
 
 
@@ -73,53 +97,50 @@ def receive_message(sock: socket.socket, timeout: float = 30.0) -> Optional[str]
             response = json.loads(response_str)
             print(response['result'])
     """
+    old_timeout = sock.gettimeout()
     try:
         # Set socket timeout
-        old_timeout = sock.gettimeout()
         sock.settimeout(timeout)
-        
-        # Read the 4-byte length prefix
+
+        # Read the 4-byte length prefix (None => connection closed)
         length_bytes = _recv_exact(sock, 4)
-        if not length_bytes:
-            sock.settimeout(old_timeout)
+        if length_bytes is None:
             return None
-            
+
         # Unpack length
         message_len = struct.unpack('>I', length_bytes)[0]
-        
+
         # Validate length (prevent memory attacks and accidental token waste)
-        MAX_MESSAGE_SIZE = 50 * 1024  # 50KB = ~15K tokens (~7.5% of daily Pro budget)
         if message_len > MAX_MESSAGE_SIZE:
-            message_kb = message_len / 1024
             est_tokens = int(message_len / 3.5)
-            print(f"❌ Message too large: {message_kb:.1f}KB ({est_tokens:,} tokens)")
-            print(f"   Current limit: {MAX_MESSAGE_SIZE/1024:.0f}KB to prevent accidental token waste")
-            print(f"   To raise limit: Edit mcp_bridge_framing.py line ~214, change MAX_MESSAGE_SIZE")
-            print(f"   ⚠️  Be aware: This message would cost ~{est_tokens:,} tokens!")
-            sock.settimeout(old_timeout)
+            _log(f"❌ Message too large: {message_len/1024:.1f}KB ({est_tokens:,} tokens); "
+                 f"limit {MAX_MESSAGE_SIZE/1024:.0f}KB. To raise it, change MAX_MESSAGE_SIZE "
+                 f"in mcp_bridge_framing.py (and the matching copy in freecad_mcp_handler.py).")
             return None
-        
-        # Read the exact number of message bytes
+
+        # Read the exact number of message bytes. message_len may legitimately be
+        # 0 (an empty-body frame); _recv_exact returns b'' for that and None only
+        # on a closed connection, so distinguish with `is None` — never falsiness,
+        # which would misread a valid empty frame as a disconnect.
         message_bytes = _recv_exact(sock, message_len)
-        if not message_bytes:
-            sock.settimeout(old_timeout)
+        if message_bytes is None:
             return None
-            
-        # Restore original timeout
-        sock.settimeout(old_timeout)
-        
+
         # Decode and return
         return message_bytes.decode('utf-8')
-        
+
     except socket.timeout:
-        print("⚠️  Socket receive timeout")
+        _log("⚠️  Socket receive timeout")
         return None
     except UnicodeDecodeError as e:
-        print(f"❌ Message decode error: {e}")
+        _log(f"❌ Message decode error: {e}")
         return None
     except Exception as e:
-        print(f"❌ Receive error: {e}")
+        _log(f"❌ Receive error: {e}")
         return None
+    finally:
+        # Always restore the caller's timeout, even on an exception path.
+        sock.settimeout(old_timeout)
 
 
 def _recv_exact(sock: socket.socket, num_bytes: int) -> Optional[bytes]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freecad-mcp"
-version = "5.9.0"
+version = "5.10.0"
 description = "MCP server to control FreeCAD from Claude"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.27.1",
+    "mcp>=1.27.2",
     "mcp-events>=0.1.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Protocol (bridge dependency)
-mcp==1.27.1
+mcp==1.27.2
 mcp-events>=0.1.0
 
 # FreeCAD's Python bindings come with FreeCAD (PySide2/PySide6)

--- a/tests/integration/test_draft_ops.py
+++ b/tests/integration/test_draft_ops.py
@@ -74,7 +74,11 @@ class TestDraftClone:
         })
         result_str = str(result)
         assert "Unknown" not in result_str
-        assert "error" not in result_str.lower() or "clone" in result_str.lower()
+        # A successful clone names the created object. Assert that positively and
+        # that there's no error — the old `... or "clone" in ...` was a tautology
+        # (a success string always contains "clone"), so it never caught failure.
+        assert "clone" in result_str.lower()
+        assert "error" not in result_str.lower()
 
     def test_clone_missing_object(self, clean_document):
         result = send_command("draft_operations", {

--- a/tests/integration/test_measurement_ops.py
+++ b/tests/integration/test_measurement_ops.py
@@ -192,9 +192,11 @@ class TestCheckSolid:
 
 class TestMeasureDistance:
     def test_measure_distance_two_boxes(self, clean_document):
-        """Center-to-center distance between two 10mm boxes 30mm apart = 30.00 mm.
+        """Minimum (face-to-face) distance between two 10mm boxes = 20.00 mm.
 
-        Box A center = (5, 5, 5); Box B center = (35, 5, 5); distance = 30.
+        measure_distance uses Shape.distToShape, i.e. the closest-point gap, not
+        center-to-center. Box A spans x[0,10], Box B spans x[30,40], so the gap
+        is 30 - 10 = 20 mm. (The handler reports 0 for touching/overlap.)
         """
         send_command("part_operations", {
             "operation": "box",
@@ -214,5 +216,5 @@ class TestMeasureDistance:
         assert_op_succeeded(result, "measure_distance")
         text = _text(result)
         assert "Distance" in text or "distance" in text
-        # Center-to-center: (5,5,5) → (35,5,5) = 30 mm
-        assert "30.00" in text, f"Expected distance 30.00 in: {text[:300]}"
+        # Min gap (face-to-face): x[0,10] → x[30,40] = 20 mm
+        assert "20.00" in text, f"Expected distance 20.00 in: {text[:300]}"

--- a/tests/unit/_freecad_mocks.py
+++ b/tests/unit/_freecad_mocks.py
@@ -277,14 +277,19 @@ def make_mock_doc(objects: Optional[Iterable[Any]] = None, name: str = "TestDoc"
         obj.TypeId = type_id
         obj.Placement = _Placement()
         obj.Visibility = True
+        # A freshly created object reports a valid, non-null shape by default so
+        # handlers that verify the result before hiding sources (boolean ops) see
+        # success. Tests wanting a failed op override obj.Shape.isNull explicitly.
+        obj.Shape.isNull = MagicMock(return_value=False)
+        obj.Shape.isValid = MagicMock(return_value=True)
         doc.Objects.append(obj)
         return obj
 
     doc.getObject = _get_object
     doc.getObjectsByLabel = _get_objects_by_label
     doc.addObject = MagicMock(side_effect=_add_object)
-    doc.copyObject = MagicMock(side_effect=lambda o: _add_object(getattr(o, 'TypeId', 'Part::Feature'),
-                                                                  f"{o.Name}_copy"))
+    doc.copyObject = MagicMock(side_effect=lambda o, with_deps=False: _add_object(
+        getattr(o, 'TypeId', 'Part::Feature'), f"{o.Name}_copy"))
     doc.removeObject = MagicMock()
     doc.recompute = MagicMock()
     doc.FileName = ''
@@ -312,6 +317,7 @@ def _make_shape(volume=1000.0, faces=6, edges=12, vertices=8,
     shape.BoundBox = bb
 
     shape.isValid = MagicMock(return_value=is_valid)
+    shape.isNull = MagicMock(return_value=not is_valid)
     shape.isClosed = MagicMock(return_value=is_closed)
     shape.check = MagicMock()
     shape.copy = MagicMock(return_value=shape)

--- a/tests/unit/test_boolean_ops.py
+++ b/tests/unit/test_boolean_ops.py
@@ -124,7 +124,10 @@ class TestCutObjects(unittest.TestCase):
         self.assertEqual(cut.Base, base)
         self.assertEqual(cut.Tool, tool)
 
-    def test_multiple_tools_assigned_as_list(self):
+    def test_multiple_tools_fused_then_cut(self):
+        """>1 tool: tools are fused into a Part::MultiFuse, which becomes the
+        single Cut.Tool. Assigning a list directly to Part::Cut.Tool raises
+        'Type must be App.DocumentObject or None, not list' in real FreeCAD."""
         base = make_box_object("Base")
         t1 = make_box_object("T1")
         t2 = make_box_object("T2")
@@ -135,9 +138,11 @@ class TestCutObjects(unittest.TestCase):
             'base': 'Base', 'tools': ['T1', 'T2'],
         })
 
-        cut = doc.Objects[-1]
+        cut = next(o for o in doc.Objects if o.TypeId == "Part::Cut")
+        fusion = next(o for o in doc.Objects if o.TypeId == "Part::MultiFuse")
         self.assertEqual(cut.Base, base)
-        self.assertEqual(list(cut.Tool), [t1, t2])
+        self.assertEqual(cut.Tool, fusion)
+        self.assertEqual(list(fusion.Shapes), [t1, t2])
 
     def test_cut_hides_base_and_tools(self):
         base = make_box_object("Base")

--- a/tests/unit/test_boolean_ops.py
+++ b/tests/unit/test_boolean_ops.py
@@ -8,6 +8,7 @@ shape parameter assembly, source visibility hiding, and error paths
 """
 
 import unittest
+from unittest.mock import MagicMock
 
 from tests.unit._freecad_mocks import (
     mock_FreeCAD,
@@ -63,6 +64,28 @@ class TestFuseObjects(unittest.TestCase):
         # Sources hidden after fuse
         self.assertFalse(a.Visibility)
         self.assertFalse(b.Visibility)
+
+    def test_fuse_null_result_keeps_sources_visible(self):
+        """If the boolean yields a null shape (non-manifold/coincident geometry),
+        the sources must stay visible and the handler must report failure — not
+        hide them behind an empty result."""
+        a = make_box_object("A")
+        b = make_box_object("B")
+        doc = make_mock_doc([a, b])
+        mock_FreeCAD.ActiveDocument = doc
+        base_add = doc.addObject.side_effect
+
+        def add_null(type_id, name=None):
+            obj = base_add(type_id, name)
+            obj.Shape.isNull = MagicMock(return_value=True)
+            return obj
+        doc.addObject.side_effect = add_null
+
+        result = self.handler.fuse_objects({'objects': ['A', 'B'], 'name': 'Union'})
+
+        self.assertIn("empty/invalid", result)
+        self.assertTrue(a.Visibility)   # sources NOT hidden on failure
+        self.assertTrue(b.Visibility)
 
     def test_fuse_three_objects(self):
         a = make_box_object("A")

--- a/tests/unit/test_bridge_framing.py
+++ b/tests/unit/test_bridge_framing.py
@@ -15,7 +15,7 @@ import os
 # Add project root to path so we can import mcp_bridge_framing
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 
-from mcp_bridge_framing import send_message, receive_message, _recv_exact
+from mcp_bridge_framing import send_message, receive_message, _recv_exact, MAX_MESSAGE_SIZE
 
 
 # ---------------------------------------------------------------------------
@@ -106,6 +106,54 @@ class TestSendMessage:
             raw = peer.recv(4096)
             length = struct.unpack(">I", raw[:4])[0]
             assert length == 0
+        finally:
+            client.close()
+            peer.close()
+
+    def test_send_exactly_max_succeeds(self):
+        """A body of exactly MAX_MESSAGE_SIZE bytes is allowed — the cap is a
+        strict greater-than, so the boundary value must still transmit.
+
+        MAX_MESSAGE_SIZE (50 KiB) is far larger than the socket send buffer
+        (~8 KiB on macOS AF_UNIX), so the peer must be drained concurrently or
+        sendall() would block forever waiting for buffer space.
+        """
+        client, peer = make_socketpair()
+        received = bytearray()
+
+        def drain():
+            while True:
+                chunk = peer.recv(65536)
+                if not chunk:
+                    break
+                received.extend(chunk)
+
+        t = threading.Thread(target=drain)
+        t.start()
+        try:
+            payload = "x" * MAX_MESSAGE_SIZE  # ASCII => 1 byte/char
+            assert send_message(client, payload) is True
+        finally:
+            client.close()        # EOF unblocks the drain thread
+            t.join(timeout=5)
+            peer.close()
+
+        assert len(received) == 4 + MAX_MESSAGE_SIZE  # length prefix + body
+        length = struct.unpack(">I", received[:4])[0]
+        assert length == MAX_MESSAGE_SIZE
+
+    def test_send_oversized_refused(self):
+        """One byte over the cap must be refused (return False) and nothing put
+        on the wire — sending it would let the peer reject the body and desync
+        every subsequent frame."""
+        client, peer = make_socketpair()
+        try:
+            big = "x" * (MAX_MESSAGE_SIZE + 1)
+            assert send_message(client, big) is False
+            # Nothing should have been transmitted.
+            peer.setblocking(False)
+            with pytest.raises((BlockingIOError, socket.error)):
+                peer.recv(4096)
         finally:
             client.close()
             peer.close()
@@ -322,21 +370,13 @@ class TestMaxMessageSizeThreshold:
             client.close()
             peer.close()
 
-    @pytest.mark.xfail(
-        reason=(
-            "Bug: receive_message can't distinguish a 0-length frame from a "
-            "closed connection.  In receive_message, after _recv_exact(sock, 0) "
-            "returns b'', `if not message_bytes: return None` fires and the "
-            "empty string is lost.  send_message happily encodes empty strings "
-            "(see test_send_empty_string), making this an asymmetric protocol "
-            "bug.  Test pinned at xfail so a future fix flips it to pass."
-        ),
-        strict=True,
-    )
     def test_zero_length_is_accepted(self):
-        """Length == 0 should be a valid empty message — the sender-side
-        test already covers framing of empty strings, so the receive side
-        ought to round-trip them.  Currently it returns None instead."""
+        """Length == 0 is a valid empty message and must round-trip.
+
+        receive_message distinguishes a 0-length frame (_recv_exact returns b'')
+        from a closed connection (_recv_exact returns None) by testing `is None`,
+        not falsiness — so the empty string is preserved rather than misread as a
+        disconnect. (Previously an xfail; fixed in the framing hardening pass.)"""
         client, peer = make_socketpair()
         try:
             peer.sendall(struct.pack(">I", 0))

--- a/tests/unit/test_cam_wrappers.py
+++ b/tests/unit/test_cam_wrappers.py
@@ -140,6 +140,26 @@ class TestCreateTool(unittest.TestCase):
         # attach_to_doc called with the active doc
         tool_bit.attach_to_doc.assert_called_once_with(doc=doc)
 
+    def test_zero_valued_params_not_dropped(self):
+        """A legitimately-supplied 0 must be written, not dropped by a falsy
+        check (flute_length=0 / number_of_flutes=0 are real values)."""
+        doc = make_mock_doc()
+        mock_FreeCAD.ActiveDocument = doc
+        tool_bit = MagicMock()
+        tool_bit.attach_to_doc = MagicMock(return_value=make_tool_bit_obj("Z", "endmill"))
+        mock_Path_Tool_Bit.ToolBit = MagicMock()
+        mock_Path_Tool_Bit.ToolBit.from_dict = MagicMock(return_value=tool_bit)
+
+        self.handler.create_tool({
+            'name': 'Z', 'tool_type': 'endmill', 'diameter': 6.0,
+            'flute_length': 0, 'shank_diameter': 0, 'number_of_flutes': 0,
+        })
+
+        params = mock_Path_Tool_Bit.ToolBit.from_dict.call_args.args[0]['parameter']
+        self.assertEqual(params['CuttingEdgeHeight']['value'], '0 mm')
+        self.assertEqual(params['ShankDiameter']['value'], '0 mm')
+        self.assertEqual(params['Flutes']['value'], 0)
+
     def test_v_bit_alias_normalized(self):
         """Both 'vbit' and 'v-bit' map to ShapeID 'vbit'."""
         doc = make_mock_doc()

--- a/tests/unit/test_cam_wrappers.py
+++ b/tests/unit/test_cam_wrappers.py
@@ -466,5 +466,64 @@ class TestCreateJob(unittest.TestCase):
         mock_Path_Main_Job.Create.assert_called_once()
 
 
+class TestCreateToolShapes(unittest.TestCase):
+    def setUp(self):
+        reset_mocks()
+        self.handler = make_handler(CAMToolsHandler)
+
+    def test_radius_and_taperedballnose_accepted(self):
+        """Shipped FC 1.2 shapes the map previously rejected as unknown."""
+        for shape in ("radius", "taperedballnose"):
+            doc = make_mock_doc()
+            mock_FreeCAD.ActiveDocument = doc
+            tool_bit = MagicMock()
+            tool_bit.attach_to_doc = MagicMock(return_value=make_tool_bit_obj("T", shape))
+            mock_Path_Tool_Bit.ToolBit = MagicMock()
+            mock_Path_Tool_Bit.ToolBit.from_dict = MagicMock(return_value=tool_bit)
+            result = self.handler.create_tool({'name': 'T', 'tool_type': shape, 'diameter': 6})
+            self.assertNotIn("Unknown tool type", result)
+            tool_dict = mock_Path_Tool_Bit.ToolBit.from_dict.call_args.args[0]
+            self.assertEqual(tool_dict['shape'], shape)
+
+
+class TestUpdateTool(unittest.TestCase):
+    def setUp(self):
+        reset_mocks()
+        self.handler = make_handler(CAMToolsHandler)
+
+    def test_material_writable(self):
+        """Material is settable at creation but previously had no update path."""
+        tool = make_tool_bit_obj("EM6", "endmill", 6)
+        doc = make_mock_doc([tool])
+        mock_FreeCAD.ActiveDocument = doc
+        self.handler.update_tool({'tool_name': 'EM6', 'material': 'HSS'})
+        self.assertEqual(tool.Material, 'HSS')
+
+
+class TestUpdateToolController(unittest.TestCase):
+    def setUp(self):
+        reset_mocks()
+        self.handler = make_handler(CAMToolControllersHandler)
+
+    def test_rapids_and_spindle_dir_writable(self):
+        """SpindleDir/HorizRapid/VertRapid are readable via get_tool_controller
+        but previously had no write path. Rapids use the same mm/min->mm/s
+        convention as feeds."""
+        controller = MagicMock()
+        controller.Name = "TC1"
+        controller.Label = "TC1"
+        doc = make_mock_doc([controller])
+        mock_FreeCAD.ActiveDocument = doc
+
+        self.handler.update_tool_controller({
+            'job_name': 'Job', 'controller_name': 'TC1',
+            'spindle_dir': 'Forward', 'horiz_rapid': 3000, 'vert_rapid': 1500,
+        })
+
+        self.assertEqual(controller.SpindleDir, 'Forward')
+        self.assertAlmostEqual(controller.HorizRapid, 50.0)   # 3000 / 60
+        self.assertAlmostEqual(controller.VertRapid, 25.0)    # 1500 / 60
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/test_crash_report.py
+++ b/tests/unit/test_crash_report.py
@@ -1,0 +1,100 @@
+"""Unit tests for freecad_crash_report crash-report parsing.
+
+macOS 12+ writes JSON .ips crash reports; the parser must handle them — the
+previous plaintext-only parser produced empty output on every modern .ips.
+It must also capture the ACTUAL crashed thread, not a hardcoded Thread 0.
+
+The .ips fixtures below mirror the structure of a real captured FreeCADCmd
+SIGSEGV report (exception / termination / faultingThread / threads / usedImages).
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import freecad_crash_report as cr
+
+
+def _ips(header, body):
+    """Build .ips content: a JSON header line followed by the JSON body."""
+    return json.dumps(header) + "\n" + json.dumps(body)
+
+
+class TestIpsParsing:
+    def _sample(self):
+        header = {"app_name": "FreeCADCmd", "app_version": "1.2.0",
+                  "os_version": "macOS 15.7"}
+        body = {
+            "exception": {"type": "EXC_BAD_ACCESS", "signal": "SIGSEGV",
+                          "subtype": "KERN_INVALID_ADDRESS at 0x0"},
+            "termination": {"namespace": "SIGNAL", "code": 11,
+                            "indicator": "Segmentation fault: 11"},
+            "faultingThread": 1,
+            "threads": [
+                {"frames": [{"imageOffset": 10, "imageIndex": 0}]},
+                {"triggered": True, "frames": [
+                    {"imageOffset": 2628, "symbol": "_platform_strlen",
+                     "symbolLocation": 4, "imageIndex": 0},
+                    {"imageOffset": 96, "symbol": "string_at", "imageIndex": 1},
+                ]},
+            ],
+            "usedImages": [
+                {"name": "libsystem_platform.dylib"},
+                {"name": "_ctypes.so", "path": "/x/_ctypes.so"},
+            ],
+        }
+        return _ips(header, body)
+
+    def test_extracts_exception_and_crashed_thread(self):
+        out = cr._parse_crash_report(self._sample(), "/x/FreeCADCmd-1.ips")
+        assert "EXC_BAD_ACCESS" in out
+        assert "SIGSEGV" in out
+        assert "KERN_INVALID_ADDRESS" in out
+        # The crashed thread is #1 (faultingThread), not 0.
+        assert "Crashed thread 1" in out
+        # Symbolicated frames present, named via usedImages.
+        assert "_platform_strlen" in out
+        assert "libsystem_platform.dylib" in out
+
+    def test_ips_does_not_fall_back_to_empty_plaintext_output(self):
+        """A JSON .ips must NOT degrade to the old '[name]' header-only output."""
+        out = cr._parse_crash_report(self._sample(), "/x/FreeCADCmd-1.ips")
+        assert out.strip() != "[FreeCADCmd-1.ips]"
+        assert len(out.splitlines()) > 3
+
+    def test_faulting_thread_falls_back_to_triggered_flag(self):
+        """When faultingThread is absent, use the thread's triggered flag."""
+        header = {"app_name": "FreeCAD"}
+        body = {"exception": {"type": "EXC_BAD_ACCESS", "signal": "SIGSEGV"},
+                "threads": [{"frames": []},
+                            {"triggered": True,
+                             "frames": [{"symbol": "boom", "imageIndex": 0}]}],
+                "usedImages": [{"name": "FreeCADApp.so"}]}
+        out = cr._parse_crash_report(_ips(header, body), "/x/FreeCAD-2.ips")
+        assert "Crashed thread 1" in out
+        assert "boom" in out
+
+
+class TestLegacyCrashParsing:
+    def test_picks_actual_crashed_thread_not_thread_0(self):
+        """Legacy plaintext .crash: capture the 'Crashed Thread: N' block, not
+        the hardcoded Thread 0 (whose stack is NOT the crash backtrace)."""
+        content = "\n".join([
+            "Exception Type:  EXC_BAD_ACCESS (SIGSEGV)",
+            "Crashed Thread:  3",
+            "",
+            "Thread 0:",
+            "0  libsystem  start + 1",
+            "",
+            "Thread 3 Crashed:",
+            "0  FreeCADApp  real_crash_frame + 42",
+            "1  FreeCADApp  caller + 8",
+            "",
+        ])
+        out = cr._parse_crash_report(content, "/x/FreeCAD.crash")
+        assert "Crashed thread 3" in out
+        assert "real_crash_frame" in out
+        # Must NOT have grabbed Thread 0's (non-crash) frames instead.
+        assert "start + 1" not in out

--- a/tests/unit/test_dispatch_completeness.py
+++ b/tests/unit/test_dispatch_completeness.py
@@ -86,6 +86,31 @@ def extract_handler_routable_names(src: str) -> set:
     return names
 
 
+def extract_bridge_dispatched_names(src: str) -> set:
+    """Pull every tool name the BRIDGE's handle_call_tool actually dispatches.
+
+    The bridge decides what to do with each tool in an if/elif chain on
+    ``name`` *before* anything reaches the FreeCAD-side handler. A tool can be
+    registered in handle_list_tools AND routable in the handler yet still be
+    unreachable, because this chain has no branch for it and it falls through
+    to the ``Unknown tool`` else. That is exactly how geometric_verification,
+    fixture_operations, run_inspector and get_last_traceback shipped dead in
+    PR #21 — extract_handler_routable_names found them (the handler routes
+    them), so the handler-side completeness test passed while the tools were
+    unreachable. Sources:
+      * ``name == "x"`` / ``elif name == "x"`` comparisons
+      * names inside an ``elif name in ["a", "b", ...]`` list (possibly
+        spanning several lines)
+    """
+    names = set()
+    for m in re.finditer(r'\bname\s*==\s*["\']([a-zA-Z_][a-zA-Z0-9_]*)["\']', src):
+        names.add(m.group(1))
+    for block in re.finditer(r'\bname\s+in\s*\[(.*?)\]', src, re.DOTALL):
+        for m in re.finditer(r'["\']([a-zA-Z_][a-zA-Z0-9_]*)["\']', block.group(1)):
+            names.add(m.group(1))
+    return names
+
+
 class TestDispatchCompleteness(unittest.TestCase):
     """Fail fast if any registered MCP tool lacks a handler dispatch."""
 
@@ -95,6 +120,7 @@ class TestDispatchCompleteness(unittest.TestCase):
         cls.handler_src = _read(HANDLER_PY)
         cls.server_tools = extract_server_tool_names(cls.server_src)
         cls.handler_tools = extract_handler_routable_names(cls.handler_src)
+        cls.bridge_dispatched = extract_bridge_dispatched_names(cls.server_src)
 
     def test_server_has_tools(self):
         """Sanity: the parser must find a reasonable number of tools."""
@@ -128,6 +154,39 @@ class TestDispatchCompleteness(unittest.TestCase):
               "If the tool is intentionally bridge-only (no FreeCAD call), "
               "add it to BRIDGE_ONLY_TOOLS in this test."
         )
+
+    def test_every_server_tool_is_dispatched_by_bridge(self):
+        """Each registered MCP tool must have a branch in the BRIDGE's
+        handle_call_tool dispatch, not just a route in the handler.
+
+        Regression for PR #21: geometric_verification, fixture_operations,
+        run_inspector and get_last_traceback were registered and handler-
+        routable, but the bridge's if/elif chain had no branch for them, so
+        every call fell through to 'Unknown tool'. The handler-side test above
+        could not catch this — only the bridge dispatch can.
+        """
+        undispatched = (self.server_tools
+                        - self.bridge_dispatched)
+        self.assertEqual(
+            undispatched, set(),
+            f"\nMCP tool(s) advertised in handle_list_tools() with no branch in "
+            f"the bridge's handle_call_tool dispatch (they return 'Unknown "
+            f"tool'):\n  " + "\n  ".join(sorted(undispatched))
+            + "\n\nFix: add the name to the smart-dispatcher `elif name in [...]` "
+              "list (for socket-routed tools) or give it its own `elif name == "
+              "...` branch in freecad_mcp_server.py."
+        )
+
+    def test_previously_dead_tools_now_dispatched(self):
+        """Canary: the four tools that were unreachable in PR #21 must stay
+        dispatched by the bridge."""
+        for tool in ("geometric_verification", "fixture_operations",
+                     "run_inspector", "get_last_traceback"):
+            self.assertIn(
+                tool, self.bridge_dispatched,
+                f"{tool} is advertised but not dispatched by the bridge — the "
+                f"PR #21 dead-tool regression has recurred."
+            )
 
     def test_no_orphan_bridge_only_entries(self):
         """Items on the BRIDGE_ONLY_TOOLS list should still exist as MCP tools.

--- a/tests/unit/test_document_ops.py
+++ b/tests/unit/test_document_ops.py
@@ -292,6 +292,23 @@ class TestListObjectsDegeneratePagination:
         result = json.loads(doc_handler.list_objects({"limit": 501}))
         assert result["limit"] == 500
 
+    def test_cap_actually_limits_returned_objects(self, doc_handler, mock_freecad):
+        """The cap must limit the OUTPUT, not just the echoed `limit` field.
+        With 501 objects and limit=500, exactly 500 come back and has_more is
+        True. The other cap tests use 10 objects, so dropping min(...,500) on the
+        slice would pass unnoticed there — this is the test that catches it."""
+        self._make_doc(mock_freecad, n_objects=501)
+        result = json.loads(doc_handler.list_objects({"limit": 500}))
+        assert result["returned"] == 500
+        assert result["has_more"] is True
+
+    def test_limit_499_returns_499(self, doc_handler, mock_freecad):
+        """Off-by-one below the cap: limit=499 returns 499 of 600."""
+        self._make_doc(mock_freecad, n_objects=600)
+        result = json.loads(doc_handler.list_objects({"limit": 499}))
+        assert result["returned"] == 499
+        assert result["has_more"] is True
+
     def test_truncation_detectable_via_total_minus_returned(self, doc_handler, mock_freecad):
         """When total > returned, the caller should be able to detect
         truncation.  The handler doesn't return a `truncated` flag, but

--- a/tests/unit/test_document_ops.py
+++ b/tests/unit/test_document_ops.py
@@ -350,6 +350,16 @@ class TestListObjectsDegeneratePagination:
         assert result["offset"] == 200
         assert result["has_more"] is False
 
+    def test_objects_carry_visibility_state_and_dependency_graph(self, doc_handler, mock_freecad):
+        """Each object must surface visibility, recompute State, and the
+        InList/OutList dependency graph (guarded; null when unavailable) so
+        callers don't need a per-object get_object_properties round-trip."""
+        self._make_doc(mock_freecad, n_objects=1)
+        result = json.loads(doc_handler.list_objects({}))
+        obj = result["objects"][0]
+        for key in ("visible", "state", "in_list", "out_list"):
+            assert key in obj, f"missing {key} in list_objects entry"
+
 
 # ---------------------------------------------------------------------------
 # hide_object / show_object / delete_object

--- a/tests/unit/test_document_ops.py
+++ b/tests/unit/test_document_ops.py
@@ -303,6 +303,53 @@ class TestListObjectsDegeneratePagination:
         assert result["returned"] == 100
         assert result["total"] - result["returned"] == 500
 
+    def _make_doc_mixed(self, mock_freecad, n_part, n_other):
+        """Document with n_part Part::Feature objects and n_other Part::Box."""
+        doc = MagicMock()
+        objs = []
+        for i in range(n_part):
+            obj = MagicMock()
+            obj.Name = f"Feat{i:04d}"
+            obj.Label = f"Feat{i:04d}"
+            obj.TypeId = "Part::Feature"
+            objs.append(obj)
+        for i in range(n_other):
+            obj = MagicMock()
+            obj.Name = f"Box{i:04d}"
+            obj.Label = f"Box{i:04d}"
+            obj.TypeId = "Part::Box"
+            objs.append(obj)
+        doc.Objects = objs
+        mock_freecad.ActiveDocument = doc
+        return doc
+
+    def test_filtered_total_reflects_type_filter(self, doc_handler, mock_freecad):
+        """With a type_filter active, filtered_total must count only matching
+        objects, not the whole document — otherwise a caller can't compute
+        page count. `total` still reports the document size."""
+        self._make_doc_mixed(mock_freecad, n_part=3, n_other=7)
+        result = json.loads(doc_handler.list_objects({"type_filter": "Box"}))
+        assert result["total"] == 10            # whole document
+        assert result["filtered_total"] == 7    # only Part::Box
+        assert result["returned"] == 7
+        assert result["has_more"] is False
+
+    def test_has_more_true_when_more_pages(self, doc_handler, mock_freecad):
+        """has_more must be True when matching objects extend past the page."""
+        self._make_doc(mock_freecad, n_objects=250)
+        result = json.loads(doc_handler.list_objects({"limit": 100, "offset": 0}))
+        assert result["returned"] == 100
+        assert result["filtered_total"] == 250
+        assert result["has_more"] is True
+
+    def test_has_more_false_on_last_page(self, doc_handler, mock_freecad):
+        """has_more must be False once the page reaches the end."""
+        self._make_doc(mock_freecad, n_objects=250)
+        result = json.loads(doc_handler.list_objects({"limit": 100, "offset": 200}))
+        assert result["returned"] == 50
+        assert result["offset"] == 200
+        assert result["has_more"] is False
+
 
 # ---------------------------------------------------------------------------
 # hide_object / show_object / delete_object

--- a/tests/unit/test_draft_ops.py
+++ b/tests/unit/test_draft_ops.py
@@ -319,6 +319,14 @@ class TestShapeString(unittest.TestCase):
             result = self.handler.shape_string({'string': 'Hi'})
         assert_error_contains(self, result, "no font", ".ttf")
 
+    def test_empty_string_rejected(self):
+        """Whitespace-only string is rejected up front (otherwise it yields an
+        empty compound or an opaque swallowed error)."""
+        doc = make_mock_doc()
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.shape_string({'string': '   '})
+        self.assertIn("non-empty string", result)
+
     def test_creates_shapestring_via_make_shapestring(self):
         """Happy path: find_font returns a path, Draft.make_shapestring
         produces an object, handler labels it and returns success.

--- a/tests/unit/test_freecad_health.py
+++ b/tests/unit/test_freecad_health.py
@@ -9,6 +9,7 @@ Run with: python3 -m pytest tests/unit/test_freecad_health.py -v
 
 import json
 import os
+import struct
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
@@ -122,7 +123,8 @@ class TestCheckSocketResponsive:
 
         mock_sock = MagicMock()
         mock_socket_cls.return_value = mock_sock
-        mock_sock.recv.return_value = b'{"status": "ok"}'
+        body = b'{"result": "pong"}'
+        mock_sock.recv.side_effect = [struct.pack(">I", len(body)), body]
 
         responsive, error = m.check_socket_responsive(timeout=1.0)
         assert responsive is True
@@ -130,6 +132,12 @@ class TestCheckSocketResponsive:
         mock_sock.settimeout.assert_called_once_with(1.0)
         mock_sock.connect.assert_called_once_with(str(sock_path))
         mock_sock.close.assert_called_once()
+        # The request must be length-prefixed framing with a {"tool", "args"}
+        # body — not the old newline-delimited {"method": ...} message.
+        sent = mock_sock.sendall.call_args[0][0]
+        assert struct.unpack(">I", sent[:4])[0] == len(sent) - 4
+        assert b'"tool"' in sent and b"test_echo" in sent
+        assert not sent.endswith(b"\n")
 
     @patch("freecad_health.socket.socket")
     def test_timeout(self, mock_socket_cls, tmp_path):
@@ -170,11 +178,11 @@ class TestCheckSocketResponsive:
 
         mock_sock = MagicMock()
         mock_socket_cls.return_value = mock_sock
-        mock_sock.recv.return_value = b""
+        mock_sock.recv.return_value = b""  # closes before sending the length prefix
 
         responsive, error = m.check_socket_responsive()
         assert responsive is False
-        assert error == "Socket connected but no response"
+        assert error == "Socket connected but closed without responding"
 
     @patch("freecad_health.socket.socket")
     def test_general_exception(self, mock_socket_cls, tmp_path):
@@ -196,7 +204,8 @@ class TestCheckSocketResponsive:
 
         mock_sock = MagicMock()
         mock_socket_cls.return_value = mock_sock
-        mock_sock.recv.return_value = b'{"ok": true}'
+        body = b'{"ok": true}'
+        mock_sock.recv.side_effect = [struct.pack(">I", len(body)), body]
 
         responsive, _ = m.check_socket_responsive()
         assert responsive is True

--- a/tests/unit/test_freecad_mcp_handler.py
+++ b/tests/unit/test_freecad_mcp_handler.py
@@ -993,6 +993,61 @@ class TestCleanupStaleAsyncJobs:
         server._cleanup_stale_async_jobs()
         assert "err1" not in server._async_jobs
 
+    def test_exactly_at_ttl_is_kept(self, server):
+        """age == TTL is NOT removed — the check is strict `>`. Pins which side
+        of the boundary the `>`/`>=` choice falls on. Time is mocked so the
+        boundary is deterministic (real time would drift age just past TTL)."""
+        import freecad_mcp_handler as ss_mod
+        from unittest.mock import patch
+        T = 1_000_000.0
+        server._async_jobs["b"] = {"status": "done", "started": T - ss_mod.ASYNC_JOB_TTL}
+        with patch.object(ss_mod.time, "time", return_value=T):
+            server._cleanup_stale_async_jobs()
+        assert "b" in server._async_jobs
+
+    def test_one_second_over_ttl_is_removed(self, server):
+        import freecad_mcp_handler as ss_mod
+        from unittest.mock import patch
+        T = 1_000_000.0
+        server._async_jobs["b"] = {"status": "done", "started": T - ss_mod.ASYNC_JOB_TTL - 1}
+        with patch.object(ss_mod.time, "time", return_value=T):
+            server._cleanup_stale_async_jobs()
+        assert "b" not in server._async_jobs
+
+
+class TestTracebackRingBuffer:
+    """Round-trip + boundary coverage for _store_traceback / _get_last_traceback
+    (the error_id mechanism that get_last_traceback depends on)."""
+
+    def test_store_then_retrieve_by_id(self, server):
+        eid = server._store_traceback("Traceback: boom")
+        assert eid == "err-0001"
+        out = json.loads(server._get_last_traceback({"error_id": eid}))
+        assert out["error_id"] == eid
+        assert out["traceback"] == "Traceback: boom"
+
+    def test_unknown_error_id_returns_error(self, server):
+        server._store_traceback("x")
+        out = json.loads(server._get_last_traceback({"error_id": "err-9999"}))
+        assert "No traceback found" in out["error"]
+
+    def test_ring_buffer_evicts_past_20(self, server):
+        for i in range(25):
+            server._store_traceback(f"tb{i}")
+        # Oldest (err-0001) evicted; newest (err-0025) retained; size capped at 20.
+        assert "error" in json.loads(server._get_last_traceback({"error_id": "err-0001"}))
+        newest = json.loads(server._get_last_traceback({"error_id": "err-0025"}))
+        assert newest["traceback"] == "tb24"
+        assert json.loads(server._get_last_traceback({}))["total_stored"] == 20
+
+    def test_count_zero_returns_all_not_none(self, server):
+        """count=0 hits the `[-0:]` == `[0:]` slice → returns ALL stored, not
+        zero. Pins a surprising boundary (the author likely meant 'none')."""
+        for i in range(3):
+            server._store_traceback(f"tb{i}")
+        out = json.loads(server._get_last_traceback({"count": 0}))
+        assert len(out["tracebacks"]) == 3
+
 
 # ---------------------------------------------------------------------------
 # _run_on_gui_thread edge cases

--- a/tests/unit/test_freecad_mcp_handler.py
+++ b/tests/unit/test_freecad_mcp_handler.py
@@ -940,6 +940,17 @@ class TestListJobs:
         assert result["jobs"]["j2"]["status"] == "done"
         assert result["jobs"]["j1"]["tool"] == "execute_python_async"
 
+    def test_label_used_when_tool_field_absent(self, server):
+        """Async jobs carry 'label' not 'tool' — list_jobs must fall back to it
+        instead of showing '?'."""
+        server._async_jobs["j3"] = {
+            "status": "running",
+            "started": time.time() - 1,
+            "label": "build_sketch",
+        }
+        result = json.loads(server._list_jobs({}))
+        assert result["jobs"]["j3"]["tool"] == "build_sketch"
+
 
 class TestCleanupStaleAsyncJobs:
     """Tests for _cleanup_stale_async_jobs."""

--- a/tests/unit/test_freecad_mcp_handler.py
+++ b/tests/unit/test_freecad_mcp_handler.py
@@ -823,6 +823,35 @@ class TestPollJob:
         # Job should be removed after retrieval
         assert "err2" not in server._async_jobs
 
+    def test_done_with_error_in_result_forwards_error_id(self, server):
+        """A task result carrying error_id must forward it so the client can
+        call get_last_traceback. Regression: _poll_job used to drop error_id,
+        making the traceback-retrieval feature dead for async errors."""
+        server._async_jobs["e_id1"] = {
+            "status": "done",
+            "started": time.time() - 1,
+            "result": {"error": "boom", "error_id": "err-0007"},
+            "elapsed": 0.5,
+            "tool": "test",
+        }
+        result = json.loads(server._poll_job({"job_id": "e_id1"}))
+        assert result["status"] == "error"
+        assert result["error_id"] == "err-0007"
+
+    def test_error_job_forwards_error_id(self, server):
+        """An error-status job with a stored error_id must forward it."""
+        server._async_jobs["e_id2"] = {
+            "status": "error",
+            "started": time.time() - 2,
+            "error": "crashed",
+            "error_id": "err-0042",
+            "elapsed": 1.0,
+            "tool": "test",
+        }
+        result = json.loads(server._poll_job({"job_id": "e_id2"}))
+        assert result["status"] == "error"
+        assert result["error_id"] == "err-0042"
+
     def test_done_job_non_dict_result(self, server):
         """If result is not a dict, should stringify it."""
         server._async_jobs["nd1"] = {

--- a/tests/unit/test_measurement_ops.py
+++ b/tests/unit/test_measurement_ops.py
@@ -232,14 +232,26 @@ class TestMeasureDistance(unittest.TestCase):
 
     def test_distance_between_two_boxes(self):
         a = make_part_object("A")
-        a.Shape.CenterOfMass = MagicMock()
-        a.Shape.CenterOfMass.distanceToPoint = MagicMock(return_value=42.5)
+        # distToShape returns [dist, points, geom_info]; [0] is the minimum
+        # surface-to-surface distance (not centroid distance).
+        a.Shape.distToShape = MagicMock(return_value=(42.5, [], []))
         b = make_part_object("B")
-        b.Shape.CenterOfMass = MagicMock()
         doc = make_mock_doc([a, b])
         mock_FreeCAD.ActiveDocument = doc
         result = self.handler.measure_distance({'object1': 'A', 'object2': 'B'})
         assert_success_contains(self, result, "42.5", "mm")
+        a.Shape.distToShape.assert_called_once_with(b.Shape)
+
+    def test_overlapping_reports_touching_not_centroid(self):
+        """Overlapping/touching parts must report ~0 surface distance and say so
+        — the old centroid-distance implementation returned a positive value."""
+        a = make_part_object("A")
+        a.Shape.distToShape = MagicMock(return_value=(0.0, [], []))
+        b = make_part_object("B")
+        doc = make_mock_doc([a, b])
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.measure_distance({'object1': 'A', 'object2': 'B'})
+        self.assertIn("touching", result.lower())
 
 
 class TestGetSurfaceArea(unittest.TestCase):

--- a/tests/unit/test_open_wire_diagnosis.py
+++ b/tests/unit/test_open_wire_diagnosis.py
@@ -330,6 +330,44 @@ class TestVerifySketchOpenWireDiagnosis:
         assert len(calls) == 1, "should have called _diagnose_open_wires once"
         assert "Open wire" in result or "open" in result.lower()
 
+    def _make_no_shape_sketch(self):
+        """Sketch that produced no Shape (e.g. fully disconnected geometry)."""
+        sketch = MagicMock()
+        sketch.Name = "Sketch"
+        sketch.TypeId = "Sketcher::SketchObject"
+        sketch.GeometryCount = 2
+        sketch.ConstraintCount = 0
+        sketch.solve = MagicMock(return_value=0)
+        sketch.Shape = None  # falsy -> the "no valid shape" branch
+        sketch.getConstruction = MagicMock(return_value=False)
+        sketch.getOpenVertices = MagicMock(return_value=[])
+        sketch.detectMissingPointOnPointConstraints = MagicMock(return_value=0)
+        return sketch
+
+    def test_no_shape_returns_invalid_not_error(self):
+        """When the sketch has no Shape, verify_sketch must reach the INVALID
+        verdict rather than raising UnboundLocalError on closed_wires/open_wires
+        (which the outer except would mask as 'Error verifying sketch')."""
+        handler = make_sketch_handler()
+        sketch = self._make_no_shape_sketch()
+
+        mock_doc = MagicMock()
+        mock_doc.getObject = MagicMock(return_value=sketch)
+        mock_doc.getObjectsByLabel = MagicMock(return_value=[sketch])
+
+        with patch.object(base_module, 'FreeCAD') as mock_fc, \
+             patch.object(sketch_ops_module, 'FreeCAD') as mock_fc2:
+            mock_fc.ActiveDocument = mock_doc
+            mock_fc2.ActiveDocument = mock_doc
+            mock_fc.Vector = FakeVectorFactory
+            mock_fc2.Vector = FakeVectorFactory
+
+            result = handler.verify_sketch({'sketch_name': 'Sketch'})
+
+        assert "Error verifying sketch" not in result
+        assert "INVALID" in result
+        assert "No valid shape" in result
+
 
 # ---------------------------------------------------------------------------
 # Tests: pad failure injects diagnosis

--- a/tests/unit/test_part_ops.py
+++ b/tests/unit/test_part_ops.py
@@ -71,6 +71,27 @@ class TestExtrude(unittest.TestCase):
 
         assert_success_contains(self, result, "x")
 
+    def test_extrude_uppercase_direction_not_silently_z(self):
+        """'X' must extrude in X — extrude used to be case-sensitive and would
+        silently fall through to Z for any non-lowercase value."""
+        sketch = make_sketch("RectS", has_wires=True)
+        doc = make_mock_doc([sketch])
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.extrude({
+            'profile_sketch': 'RectS', 'height': 5, 'direction': 'X',
+        })
+        assert_success_contains(self, result, "x")
+
+    def test_extrude_invalid_direction_errors(self):
+        """An unrecognized direction must error, not silently extrude in Z."""
+        sketch = make_sketch("RectS", has_wires=True)
+        doc = make_mock_doc([sketch])
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.extrude({
+            'profile_sketch': 'RectS', 'height': 5, 'direction': 'diagonal',
+        })
+        self.assertIn("Invalid direction", result)
+
     def test_extrude_uses_face_path_when_only_faces(self):
         """When sketch has no Wires but has Faces, fall back to Shape.extrude."""
         sketch = make_sketch("S", has_wires=False, has_faces=True)

--- a/tests/unit/test_part_ops.py
+++ b/tests/unit/test_part_ops.py
@@ -238,6 +238,15 @@ class TestScaleObject(unittest.TestCase):
         })
         assert_error_contains(self, result, "not found")
 
+    def test_scale_factor_non_positive_rejected(self):
+        """scale_factor <= 0 inverts/zeroes geometry on the non-parametric path."""
+        doc = make_mock_doc([])
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.scale_object({
+            'object_name': 'X', 'scale_factor': 0,
+        })
+        self.assertIn("scale_factor must be > 0", result)
+
 
 class TestSection(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_partdesign_ops.py
+++ b/tests/unit/test_partdesign_ops.py
@@ -594,8 +594,9 @@ class TestShellSolid(unittest.TestCase):
         shell = doc.Objects[-1]
         self.assertEqual(shell.Value, 2)
         self.assertEqual(shell.Source, box)
-        # face_idx 5 → faces tuple has 4 (0-based)
-        self.assertEqual(shell.Faces, (4,))
+        # Part::Thickness.Faces is a LinkSubList: (object, ("Face5",)) with the
+        # 1-based FaceN name — not a raw 0-based int index.
+        self.assertEqual(shell.Faces, (box, ("Face5",)))
         assert_success_contains(self, result, "2mm", "1 face")
 
 

--- a/tests/unit/test_partdesign_ops.py
+++ b/tests/unit/test_partdesign_ops.py
@@ -392,6 +392,22 @@ class TestPolarPattern(unittest.TestCase):
         self.assertEqual(doc.copyObject.call_count, 5)  # 6 - 1
         assert_success_contains(self, result, "6 instances", "Z", "360")
 
+    def test_count_zero_rejected(self):
+        """count<1 must be rejected before the `angle / count` division —
+        count=0 would otherwise raise ZeroDivisionError (swallowed as a
+        contextless generic error) and create no copies."""
+        feat = make_part_object("F")
+        feat.Label = "F"
+        doc = make_mock_doc([feat])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.polar_pattern({
+            'feature_name': 'F', 'axis': 'z', 'angle': 360, 'count': 0,
+        })
+
+        self.assertIn("count", result)
+        self.assertEqual(doc.copyObject.call_count, 0)
+
 
 class TestMirrorFeature(unittest.TestCase):
     def setUp(self):

--- a/tests/unit/test_partdesign_ops.py
+++ b/tests/unit/test_partdesign_ops.py
@@ -285,6 +285,19 @@ class TestChamferEdges(unittest.TestCase):
         doc.addObject.assert_called_with("Part::Chamfer", "Chamfer")
         assert_success_contains(self, result, "all 12")
 
+    def test_auto_select_all_no_edges_errors(self):
+        """A zero-edge object must get a clear message, not a false 'all 0 edges'
+        success or an AttributeError (mirrors _create_fillet_auto)."""
+        box = make_box_object("B")
+        box.Shape.Edges = []
+        doc = make_mock_doc([box])
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.chamfer_edges({
+            'object_name': 'B', 'distance': 0.5, 'auto_select_all': True,
+        })
+        self.assertIn("no edges to chamfer", result)
+        doc.addObject.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Hole wizard

--- a/tests/unit/test_primitives.py
+++ b/tests/unit/test_primitives.py
@@ -157,27 +157,15 @@ class TestCreateTorus(unittest.TestCase):
 # ---------------------------------------------------------------------------
 # Degenerate-dimension tests
 #
-# All existing primitives tests use round positive numbers
-# (length=25/15/10, radius=5/10).  None cover what happens when the
-# user (or an LLM-generated tool call) passes zero, negative, or
-# missing dimensions.  The handlers don't validate — they pass the
-# values straight through to Part::Box / Part::Cylinder / etc.  That
-# means:
-#
-#   - create_box(length=0, width=0, height=0) returns "Created box:
-#     ...(0x0x0mm)" with no error.  Downstream OCCT will produce a
-#     null shape that crashes any subsequent Boolean operation.
-#   - create_cylinder(radius=-5) propagates a negative radius into a
-#     Part::Cylinder, which FreeCAD silently clamps or produces an
-#     invalid shape from.
-#   - Missing 'length' falls back to default=10.  An LLM that mis-spells
-#     the key gets a 10mm default it didn't ask for, with no warning.
-#
-# These tests pin the current behavior (no validation, returns success
-# string) so a future change to add validation is intentional, not
-# accidental.  They also serve as the "what does the consumer get to
-# work with?" check — the response string is the *only* signal the
-# MCP client receives about what was created.
+# Zero/negative dimensions are now REJECTED (primitives-validation part (b)):
+#   - create_box(length=0, ...) errors naming the offending param instead of
+#     dropping a null Part::Box that crashes downstream OCCT Booleans.
+#   - create_cylinder(radius<=0 / height<=0) errors likewise.
+#   - Cone keeps its valid degenerate cases (radius2=0 pointed cone,
+#     radius1==radius2 cylinder) — see TestCreateConeDegenerateDimensions.
+#   - An OMITTED key still takes its default (length absent → 10mm); only the
+#     value validation is enforced. A *misspelled* key ('lenght') is NOT yet
+#     caught — that's part (a), still open (see primitives.py module header).
 # ---------------------------------------------------------------------------
 
 class TestCreateBoxDegenerateDimensions(unittest.TestCase):
@@ -185,10 +173,10 @@ class TestCreateBoxDegenerateDimensions(unittest.TestCase):
         reset_mocks()
         self.handler = make_handler(PrimitivesHandler)
 
-    def test_zero_dimensions_passed_through(self):
-        """length=0/width=0/height=0 produces a zero-volume Part::Box
-        with no error.  Downstream OCCT Booleans will fail; the caller
-        gets a success string with "0x0x0mm" as the only signal."""
+    def test_zero_dimensions_rejected(self):
+        """length=0/width=0/height=0 is rejected — a zero-volume Part::Box is a
+        null shape that crashes downstream OCCT Booleans, so the handler must
+        error (naming the offending param), not report success."""
         doc = make_mock_doc()
         mock_FreeCAD.ActiveDocument = doc
 
@@ -196,19 +184,14 @@ class TestCreateBoxDegenerateDimensions(unittest.TestCase):
             'length': 0, 'width': 0, 'height': 0,
         })
 
-        # No validation — the response says "Created" not "Error".
-        self.assertIn("Created box", result)
-        self.assertIn("0x0x0", result)
-        box = doc.Objects[-1]
-        self.assertEqual(box.Length, 0)
-        self.assertEqual(box.Width, 0)
-        self.assertEqual(box.Height, 0)
+        self.assertIn("Error", result)
+        self.assertIn("length", result)   # names the offending parameter
+        # No degenerate object was created.
+        doc.addObject.assert_not_called()
 
-    def test_negative_dimension_passed_through(self):
-        """Negative length is propagated to Part::Box.  FreeCAD will
-        either clamp or produce a degenerate shape — either way, the
-        handler's return value reflects what the caller asked for, so
-        a careful caller can detect the issue from the response string."""
+    def test_negative_dimension_rejected(self):
+        """Negative length is rejected rather than propagated into a degenerate
+        Part::Box."""
         doc = make_mock_doc()
         mock_FreeCAD.ActiveDocument = doc
 
@@ -216,9 +199,9 @@ class TestCreateBoxDegenerateDimensions(unittest.TestCase):
             'length': -10, 'width': 5, 'height': 5,
         })
 
-        self.assertIn("Created box", result)
-        self.assertIn("-10", result)
-        self.assertEqual(doc.Objects[-1].Length, -10)
+        self.assertIn("Error", result)
+        self.assertIn("length", result)
+        doc.addObject.assert_not_called()
 
     def test_missing_dimension_uses_default(self):
         """Missing 'length' defaults to 10mm.  An LLM that omits a key
@@ -241,27 +224,27 @@ class TestCreateCylinderDegenerateDimensions(unittest.TestCase):
         reset_mocks()
         self.handler = make_handler(PrimitivesHandler)
 
-    def test_zero_radius_passed_through(self):
-        """radius=0 yields a degenerate cylinder.  No error from the
-        handler."""
+    def test_zero_radius_rejected(self):
+        """radius=0 is a degenerate cylinder — rejected with the param named."""
         doc = make_mock_doc()
         mock_FreeCAD.ActiveDocument = doc
 
         result = self.handler.create_cylinder({'radius': 0, 'height': 10})
 
-        self.assertIn("Created cylinder", result)
-        self.assertEqual(doc.Objects[-1].Radius, 0)
+        self.assertIn("Error", result)
+        self.assertIn("radius", result)
+        doc.addObject.assert_not_called()
 
-    def test_zero_height_passed_through(self):
-        """height=0 yields a flat disk (or null shape, depending on
-        FreeCAD version).  Handler returns success."""
+    def test_zero_height_rejected(self):
+        """height=0 (flat disk / null shape) is rejected with the param named."""
         doc = make_mock_doc()
         mock_FreeCAD.ActiveDocument = doc
 
         result = self.handler.create_cylinder({'radius': 5, 'height': 0})
 
-        self.assertIn("Created cylinder", result)
-        self.assertEqual(doc.Objects[-1].Height, 0)
+        self.assertIn("Error", result)
+        self.assertIn("height", result)
+        doc.addObject.assert_not_called()
 
 
 class TestCreateConeDegenerateDimensions(unittest.TestCase):

--- a/tests/unit/test_sketch_ops.py
+++ b/tests/unit/test_sketch_ops.py
@@ -268,6 +268,47 @@ class TestAddPolygon(unittest.TestCase):
         # 6 line segments for hexagon
         self.assertEqual(s.addGeometry.call_count, 6)
 
+    def test_exactly_3_sides_makes_triangle(self):
+        """sides==3 is the boundary — must be accepted (the guard is `sides < 3`).
+        A `<`→`<=` mutant would silently kill triangles."""
+        s = _make_real_sketch_mock("S")
+        doc = make_mock_doc([s])
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.add_polygon({
+            'sketch_name': 'S', 'sides': 3, 'radius': 5,
+        })
+        assert_success_contains(self, result, "3")
+        self.assertEqual(s.addGeometry.call_count, 3)
+
+
+class TestAddSlot(unittest.TestCase):
+    def setUp(self):
+        reset_mocks()
+        self.handler = make_handler(SketchOpsHandler)
+
+    def test_length_equals_width_rejected(self):
+        """length == width → half_len == 0 → a degenerate (circular) slot. The
+        guard is `half_len <= 0`, so equal is rejected; pins which side of the
+        boundary `<=` falls on."""
+        s = _make_real_sketch_mock("S")
+        doc = make_mock_doc([s])
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.add_slot({
+            'sketch_name': 'S', 'length': 6, 'width': 6,
+        })
+        self.assertIn("must be greater", result)
+        self.assertFalse(s.addGeometry.called)
+
+    def test_length_just_over_width_succeeds(self):
+        s = _make_real_sketch_mock("S")
+        doc = make_mock_doc([s])
+        mock_FreeCAD.ActiveDocument = doc
+        result = self.handler.add_slot({
+            'sketch_name': 'S', 'length': 7, 'width': 6,
+        })
+        self.assertNotIn("must be greater", result)
+        self.assertTrue(s.addGeometry.called)
+
 
 # ---------------------------------------------------------------------------
 # add_constraint — dispatch table
@@ -300,6 +341,22 @@ class TestAddConstraint(unittest.TestCase):
 
         assert_success_contains(self, result, "Horizontal")
         # Sketcher.Constraint('Horizontal', 0)
+        sc_call = mock_Sketcher.Constraint.call_args
+        self.assertEqual(sc_call.args, ('Horizontal', 0))
+
+    def test_constraint_type_is_case_insensitive(self):
+        """'horizontal' must resolve to the canonical 'Horizontal' rather than
+        falling through to 'Unknown constraint type' (syntactic-seam fix)."""
+        s = _make_real_sketch_mock("S")
+        doc = make_mock_doc([s])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.add_constraint({
+            'sketch_name': 'S', 'constraint_type': 'horizontal',
+            'geo_id1': 0,
+        })
+
+        self.assertNotIn("Unknown", result)
         sc_call = mock_Sketcher.Constraint.call_args
         self.assertEqual(sc_call.args, ('Horizontal', 0))
 

--- a/tests/unit/test_spatial_ops.py
+++ b/tests/unit/test_spatial_ops.py
@@ -387,6 +387,18 @@ class TestFaceRelationship(unittest.TestCase):
         result = self.handler.face_relationship({'object1': 'A', 'object2': 'B'})
         self.assertIn("face1 and face2 are required", result)
 
+    def test_malformed_face_id_rejected(self):
+        """'Face1Face2' must be rejected, not silently parsed to face 12 by the
+        old unanchored replace('Face','') logic."""
+        box1 = make_box("A", 0, 0, 0, 10, 10, 10)
+        box2 = make_box("B", 15, 0, 0, 10, 10, 10)
+        self.fc.ActiveDocument = make_mock_doc([box1, box2])
+        result = self.handler.face_relationship({
+            'object1': 'A', 'object2': 'B',
+            'face1': 'Face1Face2', 'face2': 'Face1'
+        })
+        self.assertIn("Invalid face id", result)
+
     def test_parallel_faces(self):
         box1 = make_box("A", 0, 0, 0, 10, 10, 10)
         box2 = make_box("B", 15, 0, 0, 10, 10, 10)

--- a/tests/unit/test_spatial_ops.py
+++ b/tests/unit/test_spatial_ops.py
@@ -509,6 +509,19 @@ class TestBatchInterference(unittest.TestCase):
         self.assertIn("SUB-TOL", result)
         self.assertIn("Collisions: 1", result)
 
+    def test_common_failure_counted_as_failed_not_clear(self):
+        """A common() failure on one pair must be reported as failed — not abort
+        the whole batch, and not be silently counted as a clear pair."""
+        box1 = make_box("A", 0, 0, 0)
+        box2 = make_box("B", 0, 0, 0)
+        box1.Shape.BoundBox.intersect = MagicMock(return_value=True)
+        box1.Shape.common = MagicMock(side_effect=RuntimeError("OCCT boom"))
+        self.fc.ActiveDocument = make_mock_doc([box1, box2])
+        result = self.handler.batch_interference({'objects': ['A', 'B']})
+        self.assertIn("Failed (geometry error): 1", result)
+        self.assertIn("Clear: 0", result)
+        self.assertIn("Collisions: 0", result)
+
 
 class TestAlignmentCheck(unittest.TestCase):
 

--- a/tests/unit/test_spatial_ops.py
+++ b/tests/unit/test_spatial_ops.py
@@ -309,6 +309,20 @@ class TestClearance(unittest.TestCase):
         result = self.handler.clearance({'object1': 'A', 'object2': 'B'})
         self.assertIn("TOUCHING", result)
 
+    def test_sub_linear_tolerance_reports_touching(self):
+        """A gap below OCCT's linear tolerance is contact — must report TOUCHING.
+        The old threshold was _VOL_TOL (1e-9 mm³) used as a distance, far tighter
+        than OCCT's resolution, so it misreported sub-tolerance contact as a gap."""
+        box1 = make_box("A", 0, 0, 0)
+        box2 = make_box("B", 10, 0, 0)
+        box1.Shape.distToShape = MagicMock(return_value=(
+            1e-8,  # < _OCCT_LIN_TOL (~1e-7) but > _VOL_TOL (1e-9)
+            [(FakeVector(10, 5, 5), FakeVector(10, 5, 5))]
+        ))
+        self.fc.ActiveDocument = make_mock_doc([box1, box2])
+        result = self.handler.clearance({'object1': 'A', 'object2': 'B'})
+        self.assertIn("TOUCHING", result)
+
     def test_multiple_point_pairs(self):
         box1 = make_box("A")
         box2 = make_box("B", 15, 0, 0)

--- a/tests/unit/test_spreadsheet_ops.py
+++ b/tests/unit/test_spreadsheet_ops.py
@@ -84,6 +84,16 @@ class TestSetCell(unittest.TestCase):
         })
         assert_error_contains(self, result, "not a spreadsheet")
 
+    def test_set_none_value_clears_not_literal_none(self):
+        """value=None must clear the cell, not write the string 'None'."""
+        sheet = make_spreadsheet("Params")
+        doc = make_mock_doc([sheet])
+        mock_FreeCAD.ActiveDocument = doc
+        self.handler.set_cell({
+            'spreadsheet_name': 'Params', 'cell': 'A1', 'value': None,
+        })
+        self.assertEqual(sheet._cells_data.get('A1'), '')
+
     def test_set_cell_round_trips(self):
         sheet = make_spreadsheet("Params")
         doc = make_mock_doc([sheet])

--- a/tests/unit/test_spreadsheet_ops.py
+++ b/tests/unit/test_spreadsheet_ops.py
@@ -107,6 +107,7 @@ class TestGetCell(unittest.TestCase):
     def test_get_returns_cell_value_as_json(self):
         sheet = make_spreadsheet("Params")
         sheet._cells_data['B2'] = '42'  # pre-populate
+        sheet.getContents = MagicMock(return_value='42')  # stored expression
         doc = make_mock_doc([sheet])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -114,10 +115,27 @@ class TestGetCell(unittest.TestCase):
             'spreadsheet_name': 'Params', 'cell': 'B2',
         })
 
-        # JSON shape: {"cell": "B2", "value": "42"}
+        # JSON shape now carries value, type, and the stored formula so a
+        # read→write round-trip can preserve expressions.
         payload = json.loads(result)
         self.assertEqual(payload['cell'], 'B2')
         self.assertEqual(payload['value'], '42')
+        self.assertEqual(payload['formula'], '42')
+        self.assertEqual(payload['type'], 'str')
+
+    def test_get_empty_cell_value_is_json_null(self):
+        """An empty cell must serialize as JSON null, not the string 'None'."""
+        sheet = make_spreadsheet("Params")
+        sheet.get = MagicMock(return_value=None)
+        sheet.getContents = MagicMock(return_value='')
+        doc = make_mock_doc([sheet])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.get_cell({
+            'spreadsheet_name': 'Params', 'cell': 'Z9',
+        })
+        payload = json.loads(result)
+        self.assertIsNone(payload['value'])
 
 
 class TestSetAlias(unittest.TestCase):
@@ -304,6 +322,42 @@ class TestListAliases(unittest.TestCase):
         self.assertEqual(payload['aliases'], {
             'A1': 'wallThickness', 'A2': 'height',
         })
+
+
+class TestCsvRoundTrip(unittest.TestCase):
+    def setUp(self):
+        reset_mocks()
+        self.handler = make_handler(SpreadsheetOpsHandler)
+
+    def test_import_keeps_quoted_field_with_comma_in_one_cell(self):
+        """A quoted field containing the delimiter must land in a single cell —
+        naive split(',') would break it across two cells."""
+        sheet = make_spreadsheet("S")
+        doc = make_mock_doc([sheet])
+        mock_FreeCAD.ActiveDocument = doc
+
+        self.handler.import_csv({
+            'spreadsheet_name': 'S', 'start_cell': 'A1',
+            'csv_data': '"Smith, John",42\n',
+        })
+
+        self.assertEqual(sheet._cells_data.get('A1'), 'Smith, John')
+        self.assertEqual(sheet._cells_data.get('B1'), '42')
+
+    def test_export_quotes_field_with_comma(self):
+        """csv.writer must quote a comma-containing field so the CSV re-imports
+        into the correct columns; the old delimiter.join did not."""
+        sheet = make_spreadsheet("S")
+        sheet._cells_data['A1'] = 'a,b'
+        sheet._cells_data['B1'] = 'plain'
+        doc = make_mock_doc([sheet])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.export_csv({
+            'spreadsheet_name': 'S', 'start_cell': 'A1', 'end_cell': 'B1',
+        })
+        payload = json.loads(result)
+        self.assertIn('"a,b"', payload['csv'])
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_transforms.py
+++ b/tests/unit/test_transforms.py
@@ -138,8 +138,9 @@ class TestCopyObject(unittest.TestCase):
         })
 
         assert_success_contains(self, result, "copy", "20")
-        # copyObject was called once
-        doc.copyObject.assert_called_once_with(box)
+        # copyObject was called once, with_dependencies=True so parametric/
+        # body-backed objects copy their dep chain instead of referencing the source
+        doc.copyObject.assert_called_once_with(box, True)
         # The new copy's Label is set to the requested name
         copy = doc.copyObject.return_value
         # Our make_mock_doc uses side_effect, not return_value;


### PR DESCRIPTION
## Release 5.10.0 (minor)

Remediation of the whole-repo code review, worked tier by tier with a
verify-then-fix discipline (≈35% of review findings were false positives,
filtered out against real headless FreeCAD behavior rather than fixed blindly).
Version bumped 5.9.0 → **5.10.0**.

**47 files changed, +1577 / −342. 1088 unit tests green.**

### Criticals + top-8 gate
- Dispatch routing restored (4 advertised tools were unreachable)
- Oversized-message framing cluster (send-side cap, drain/close, stderr logging, single MAX_MESSAGE_SIZE)
- `elapsed_s` consumed + `error_id` forwarded; `verify_sketch` UnboundLocalError
- `list_objects` degenerate limit / filtered total; `check_complexity` off-by-one
- CAM feed-rate unit label (was 60× wrong); groove dead-axis + add_slot reversed winding

### Highs (Tier 1 + Tier 2 A–E)
- Measurement / spatial / spreadsheet silent-data-loss paths
- CAM read-back/write completeness; inspector/document fixes
- macOS `.ips` (JSON) crash-report parsing + actual-crashed-thread capture

### Mediums
- Quick-wins: seam/degenerate-input correctness (tool_type None, extrude direction case, helix turns, fillet/chamfer guards, face-id anchoring, debug-log malformed counter, byte-truncation, export_gcode error routing, macro stderr capture, spreadsheet None-cell, spindle-speed coercion)
- Verify-then-fix: clearance linear-vs-volume tolerance, shell `Faces` LinkSubList format, scale-factor guard

### Lows (Tier A — the high-value ones)
- **primitives**: reject zero/negative dimensions (null shape no longer crashes downstream OCCT); staged pinning tests flipped. (Misspelled-key rejection deferred — needs full injected-key envelope; documented.)
- boolean fuse/cut/common verify-before-hide; chamfer-auto twin-bug guard
- `copy_object` deep copy; `shape_string` empty reject; ocl `execute()` clears stale Path; `debug_deccorator` typo

### Tests
- Closed the gaps that guard the fixes: `list_objects` cap (n≥501→returned==500), error_id ring-buffer round-trip, sketch boundaries (polygon sides==3, slot length==width), ASYNC_JOB_TTL boundary
- Code fix surfaced while testing: `constraint_type` case-normalization seam

## Eyeball before merge
- `save_document` GUI-thread routing — principled, not verified in a live GUI session
- `add_slot`/`groove` geometry — verified headless, worth a visual confirm
- integration `test_draft_ops` clone assertion — strengthened but unverified against live FreeCAD

## After merge
Tag `v5.10.0` on main to trigger `release.yml` (git-cliff release notes + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)