### PR TITLE
Release 5.11.0 — FreeCAD 26.x renumber compatibility + queued fixes

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -68,13 +68,22 @@ Clone location: wherever repos live on this system. `~/freecad-mcp` is a safe de
 
 ### Step 2: Install the AICopilot workbench into FreeCAD
 
-Copy the `AICopilot` directory to FreeCAD's Mod folder:
+Copy the `AICopilot` directory to FreeCAD's Mod folder. **Do not hardcode the
+Mod path** — FreeCAD stores user data under a version-stamped directory
+(e.g. `v1-2`, `v26-3`) that changes between releases. Ask FreeCAD itself where
+its Mod folder is, then copy into it:
 
-- **macOS:** `cp -r AICopilot ~/Library/Application\ Support/FreeCAD/v1-2/Mod/`
-- **Linux:** `cp -r AICopilot ~/.local/share/FreeCAD/Mod/`
-- **Windows:** Copy `AICopilot` to `%APPDATA%\FreeCAD\Mod\`
+```bash
+# Resolve FreeCAD's actual user Mod dir (works on any version / OS):
+MOD_DIR="$(FreeCADCmd -c 'import FreeCAD, os; print(os.path.join(FreeCAD.getUserAppDataDir(), "Mod"))' 2>/dev/null | tail -1)"
+mkdir -p "$MOD_DIR"
+cp -r AICopilot "$MOD_DIR/"
+```
 
-If the Mod directory doesn't exist, create it. The `v1-2` path component on macOS matches FreeCAD 1.2; adjust if needed.
+If `FreeCADCmd` isn't on `PATH`, substitute the full binary path (or use the
+GUI's Python console: `FreeCAD.getUserAppDataDir()`). The version-stamped
+component is resolved by FreeCAD, so this stays correct across the 1.x → 26.x
+renumber and any future change.
 
 ### Step 3: Install the MCP bridge
 

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -6,11 +6,18 @@
 #                   list_freecad_instances enriched with active doc + window
 #                   title; startup banner shows handler version.
 
-# Minimum FreeCAD version required for CAM tools.
-# Below this, cam_operations / cam_tools / cam_tool_controllers return a clean
-# "not supported" error rather than crashing on missing Path/CAM API.
-__version__ = "5.10.0"
+__version__ = "5.11.0"
 
+# Minimum FreeCAD version required for CAM tools (the new Path Toolbit API).
+# Below this, cam_operations / cam_tools / cam_tool_controllers return a clean
+# "not supported" error rather than crashing on the missing Path/CAM API.
+#
+# NOTE on the value: FreeCAD's version scheme was renumbered from 1.2 to 26.3
+# (the dev series jumped 1.1 -> 26.3, skipping over 1.2 entirely). This tuple
+# threshold still gates correctly because of that gap: legacy builds without
+# the Toolbit API report (1, 0/1, x) which sort below (1, 2, 0), while every
+# build that HAS the API now reports (26, 3, 0)+ which sorts above it. Nothing
+# real lives between 1.1 and 26.3, so the boundary remains unambiguous.
 CAM_MIN_FC_VERSION = (1, 2, 0)
 
 REQUIRED_VERSIONS = {
@@ -333,11 +340,11 @@ class FreeCADSocketServer:
             minor = int(ver[1])
             patch = int(ver[2]) if len(ver) > 2 and str(ver[2]).isdigit() else 0
             self._fc_version = (major, minor, patch)
-            cam_req = ".".join(str(x) for x in CAM_MIN_FC_VERSION)
             if self._fc_version < CAM_MIN_FC_VERSION:
                 FreeCAD.Console.PrintWarning(
                     f"[MCP] FreeCAD {major}.{minor} detected. "
-                    f"CAM tools require {cam_req}+; all other tools work normally.\n"
+                    f"CAM tools require a build with the Path Toolbit API "
+                    f"(weekly / 26.x); all other tools work normally.\n"
                 )
             else:
                 FreeCAD.Console.PrintMessage(f"[MCP] FreeCAD {major}.{minor} — OK\n")
@@ -996,15 +1003,15 @@ class FreeCADSocketServer:
         if tool_name == "view_control":
             return self._dispatch_view_control(args)
 
-        # CAM version gate — return clean error on pre-1.2 FreeCAD
+        # CAM version gate — return clean error on builds without the Path Toolbit API
         _CAM_TOOLS = {"cam_operations", "cam_tools", "cam_tool_controllers"}
         if tool_name in _CAM_TOOLS and self._fc_version < CAM_MIN_FC_VERSION:
             running = ".".join(str(x) for x in self._fc_version)
-            required = ".".join(str(x) for x in CAM_MIN_FC_VERSION)
             return json.dumps({
                 "error": (
-                    f"CAM tools require FreeCAD {required} or later "
-                    f"(running {running}). Use a FreeCAD weekly build for CAM support."
+                    f"CAM tools require a FreeCAD build with the Path Toolbit API "
+                    f"(weekly builds / 26.x; running {running}). "
+                    f"Use a recent FreeCAD weekly build for CAM support."
                 )
             })
 

--- a/AICopilot/handlers/document_ops.py
+++ b/AICopilot/handlers/document_ops.py
@@ -47,9 +47,7 @@ class DocumentOpsHandler(BaseHandler):
                 except queue.Empty:
                     return "Timeout waiting for document creation"
             else:
-                doc = FreeCAD.newDocument(name)
-                doc.recompute()
-                return f"Document '{name}' created successfully"
+                return "Error: no GUI thread dispatcher available — cannot safely create document"
 
         except Exception as e:
             return f"Error in create_document: {e}"

--- a/AICopilot/handlers/primitives.py
+++ b/AICopilot/handlers/primitives.py
@@ -9,20 +9,27 @@
 #     downstream OCCT Boolean. The Test*DegenerateDimensions classes in
 #     tests/unit/test_primitives.py assert the rejection.
 #
-# (a) STILL OPEN: unknown/misspelled arg keys ('lenght' → silent 10mm default)
-#     are NOT yet rejected. This needs the *full* injected-key envelope first:
-#     _dispatch_part_operations forwards the entire args dict (it carries
-#     `operation`, and the cyber confirm-gate can add `confirmed`, plus any
-#     async/internal `_`-prefixed keys). A naive allow-list that omits one of
-#     those would reject every primitive call. Enumerate the envelope before
-#     adding strict key validation; until then a misspelled dimension key still
-#     silently takes the default.
+# (a) DONE: unknown/misspelled arg keys ('lenght' → was silent 10mm default)
+#     are now rejected via _check_unknown_keys. The injected-key envelope is:
+#     `operation` (always), `_continue_selection` + `_operation_id` (continuation
+#     path only). These are tolerated by _INJECTED_KEYS; everything else unknown
+#     returns an explicit error naming the offending keys.
 # ───────────────────────────────────────────────────────────────────────────
 
 import FreeCAD
 import FreeCADGui
 from typing import Dict, Any, Optional
 from .base import BaseHandler
+
+
+_INJECTED_KEYS = frozenset({"operation", "_continue_selection", "_operation_id"})
+
+
+def _check_unknown_keys(primitive: str, args: dict, allowed: frozenset) -> Optional[str]:
+    unknown = set(args) - allowed - _INJECTED_KEYS
+    if unknown:
+        return f"Error creating {primitive}: unknown argument(s) {sorted(unknown)} — check for typos"
+    return None
 
 
 def _validate_positive(prim: str, **dims) -> Optional[str]:
@@ -44,6 +51,9 @@ class PrimitivesHandler(BaseHandler):
     def create_box(self, args: Dict[str, Any]) -> str:
         """Create a box with specified dimensions."""
         try:
+            err = _check_unknown_keys('box', args, frozenset({'length', 'width', 'height', 'x', 'y', 'z', 'name'}))
+            if err:
+                return err
             length = args.get('length', 10)
             width = args.get('width', 10)
             height = args.get('height', 10)
@@ -77,6 +87,9 @@ class PrimitivesHandler(BaseHandler):
     def create_cylinder(self, args: Dict[str, Any]) -> str:
         """Create a cylinder with specified dimensions."""
         try:
+            err = _check_unknown_keys('cylinder', args, frozenset({'radius', 'height', 'x', 'y', 'z', 'name'}))
+            if err:
+                return err
             radius = args.get('radius', 5)
             height = args.get('height', 10)
             x = args.get('x', 0)
@@ -108,6 +121,9 @@ class PrimitivesHandler(BaseHandler):
     def create_sphere(self, args: Dict[str, Any]) -> str:
         """Create a sphere with specified radius."""
         try:
+            err = _check_unknown_keys('sphere', args, frozenset({'radius', 'x', 'y', 'z', 'name'}))
+            if err:
+                return err
             radius = args.get('radius', 5)
             x = args.get('x', 0)
             y = args.get('y', 0)
@@ -137,6 +153,9 @@ class PrimitivesHandler(BaseHandler):
     def create_cone(self, args: Dict[str, Any]) -> str:
         """Create a cone with specified radii and height."""
         try:
+            err = _check_unknown_keys('cone', args, frozenset({'radius1', 'radius2', 'height', 'x', 'y', 'z', 'name'}))
+            if err:
+                return err
             radius1 = args.get('radius1', 5)  # Bottom radius
             radius2 = args.get('radius2', 0)  # Top radius
             height = args.get('height', 10)
@@ -179,6 +198,9 @@ class PrimitivesHandler(BaseHandler):
     def create_torus(self, args: Dict[str, Any]) -> str:
         """Create a torus (donut shape) with specified radii."""
         try:
+            err = _check_unknown_keys('torus', args, frozenset({'radius1', 'radius2', 'x', 'y', 'z', 'name'}))
+            if err:
+                return err
             radius1 = args.get('radius1', 10)  # Major radius
             radius2 = args.get('radius2', 3)   # Minor radius
             x = args.get('x', 0)
@@ -210,6 +232,9 @@ class PrimitivesHandler(BaseHandler):
     def create_wedge(self, args: Dict[str, Any]) -> str:
         """Create a wedge (triangular prism) with specified dimensions."""
         try:
+            err = _check_unknown_keys('wedge', args, frozenset({'xmin', 'ymin', 'zmin', 'x2min', 'x2max', 'xmax', 'ymax', 'zmax', 'name'}))
+            if err:
+                return err
             xmin = args.get('xmin', 0)
             ymin = args.get('ymin', 0)
             zmin = args.get('zmin', 0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # On Apple Silicon: docker build --platform linux/amd64 -t freecad-mcp .
 FROM mambaorg/micromamba:latest
 
-ARG FREECAD_VERSION=1.0.0
+ARG FREECAD_VERSION=1.1.0
 
 USER root
 

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -310,6 +310,9 @@ def _find_freecadcmd() -> str | None:
         "/Applications/FreeCAD 1.0.app/Contents/MacOS/FreeCADCmd",
         "/Applications/FreeCAD 1.1.app/Contents/MacOS/FreeCADCmd",
         "/Applications/FreeCAD 1.2.app/Contents/MacOS/FreeCADCmd",
+        # Weekly / renumbered (26.x) builds ship under these bundle names
+        "/Applications/FreeCAD weekly-builds.app/Contents/MacOS/FreeCADCmd",
+        "/Applications/FreeCAD 26.app/Contents/MacOS/FreeCADCmd",
         # Local build (FC-clone)
         os.path.expanduser("~/Documents/FC-clone/build/release/bin/FreeCADCmd"),
         "/Volumes/Files/claude/FC-clone/build/release/bin/FreeCADCmd",
@@ -350,6 +353,9 @@ def _find_freecad_gui() -> str | None:
         "/Applications/FreeCAD 1.0.app/Contents/MacOS/FreeCAD",
         "/Applications/FreeCAD 1.1.app/Contents/MacOS/FreeCAD",
         "/Applications/FreeCAD 1.2.app/Contents/MacOS/FreeCAD",
+        # Weekly / renumbered (26.x) builds ship under these bundle names
+        "/Applications/FreeCAD weekly-builds.app/Contents/MacOS/FreeCAD",
+        "/Applications/FreeCAD 26.app/Contents/MacOS/FreeCAD",
         os.path.expanduser("~/Documents/FC-clone/build/release/bin/FreeCAD"),
         "/Volumes/Files/claude/FC-clone/build/release/bin/FreeCAD",
     ]
@@ -381,8 +387,11 @@ def _find_headless_script() -> str | None:
         os.path.join(bridge_dir, "AICopilot", "headless_server.py"),
         # Standard install
         os.path.expanduser("~/.freecad-mcp/AICopilot/headless_server.py"),
-        # Known addon paths (from MEMORY.md)
+        # Known addon paths (from MEMORY.md). The version-stamped component
+        # follows FreeCAD's renumbering (v1-2 -> v26-3); keep both so a freshly
+        # migrated profile and a legacy one both resolve.
         "/Volumes/Files/claude/FreeCAD-prefs/Mod/AICopilot/headless_server.py",
+        "/Volumes/Files/claude/FreeCAD-prefs/v26-3/Mod/AICopilot/headless_server.py",
         "/Volumes/Files/claude/FreeCAD-prefs/v1-2/Mod/AICopilot/headless_server.py",
     ]
     for p in candidates:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Repository = "https://github.com/blwfish/freecad-mcp"
 Issues = "https://github.com/blwfish/freecad-mcp/issues"
 
 [project.optional-dependencies]
-test = ["pytest>=9.1.0", "pip-audit>=2.10.1"]
+test = ["pytest>=9.1.1", "pip-audit>=2.10.1"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Repository = "https://github.com/blwfish/freecad-mcp"
 Issues = "https://github.com/blwfish/freecad-mcp/issues"
 
 [project.optional-dependencies]
-test = ["pytest>=9.0.3", "pip-audit>=2.10.1"]
+test = ["pytest>=9.1.0", "pip-audit>=2.10.1"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Repository = "https://github.com/blwfish/freecad-mcp"
 Issues = "https://github.com/blwfish/freecad-mcp/issues"
 
 [project.optional-dependencies]
-test = ["pytest>=9.0.3", "pip-audit>=2.10.0"]
+test = ["pytest>=9.0.3", "pip-audit>=2.10.1"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freecad-mcp"
-version = "5.10.0"
+version = "5.11.0"
 description = "MCP server to control FreeCAD from Claude"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.27.2",
+    "mcp>=1.28.0",
     "mcp-events>=0.1.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Protocol (bridge dependency)
-mcp==1.27.2
+mcp==1.28.0
 mcp-events>=0.1.0
 
 # FreeCAD's Python bindings come with FreeCAD (PySide2/PySide6)

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.blwfish/freecad-mcp",
   "title": "FreeCAD MCP",
   "description": "Control FreeCAD from Claude — 3D modeling, PartDesign, CAM toolpaths, and more via 30+ tools.",
-  "version": "5.8.1",
+  "version": "5.11.0",
   "repository": {
     "url": "https://github.com/blwfish/freecad-mcp",
     "source": "github"

--- a/tests/unit/test_document_ops.py
+++ b/tests/unit/test_document_ops.py
@@ -81,8 +81,9 @@ class TestCreateDocument:
         assert "MyDoc" in result
         assert "created" in result
 
-    def test_create_fallback_no_server(self, mock_freecad):
-        """Without server, should create document directly."""
+    def test_create_no_gui_dispatcher_errors(self, mock_freecad):
+        """Without a GUI thread dispatcher, create_document must refuse rather
+        than call FreeCAD.newDocument() off-thread (hardened in 6a4b39f)."""
         for mod in ("handlers.base", "handlers.document_ops"):
             if mod in sys.modules:
                 del sys.modules[mod]
@@ -93,9 +94,9 @@ class TestCreateDocument:
         mock_freecad.newDocument.return_value = new_doc
 
         result = handler.create_document({"document_name": "DirectDoc"})
-        assert "DirectDoc" in result
-        assert "created" in result
-        mock_freecad.newDocument.assert_called_once_with("DirectDoc")
+        assert "Error" in result
+        assert "GUI thread dispatcher" in result
+        mock_freecad.newDocument.assert_not_called()
 
     def test_create_uses_name_fallback(self, doc_handler):
         """Should fall back to 'name' arg if 'document_name' missing."""

--- a/tests/unit/test_primitives.py
+++ b/tests/unit/test_primitives.py
@@ -6,6 +6,7 @@ assignment (e62ebc5 fix), and document creation behavior.
 """
 
 import unittest
+from unittest.mock import MagicMock
 
 from tests.unit._freecad_mocks import (
     mock_FreeCAD,
@@ -324,6 +325,55 @@ class TestPrimitivesNoDocument(unittest.TestCase):
         """newDocument() must never be called from a primitive handler."""
         self.handler.create_box({'length': 10, 'width': 10, 'height': 10})
         mock_FreeCAD.newDocument.assert_not_called()
+
+
+class TestUnknownArgKeys(unittest.TestCase):
+    """Misspelled/unknown keys must be rejected immediately, not silently defaulted."""
+
+    def setUp(self):
+        self.handler = PrimitivesHandler()
+        self.handler.get_document = MagicMock(return_value=None)
+
+    def _assert_unknown_key_error(self, result, key):
+        self.assertIn("Error", result)
+        self.assertIn("unknown argument", result)
+        self.assertIn(key, result)
+
+    def test_box_misspelled_length_rejected(self):
+        result = self.handler.create_box({'lenght': 50, 'width': 10, 'height': 10})
+        self._assert_unknown_key_error(result, 'lenght')
+
+    def test_cylinder_misspelled_radius_rejected(self):
+        result = self.handler.create_cylinder({'raduis': 5, 'height': 10})
+        self._assert_unknown_key_error(result, 'raduis')
+
+    def test_sphere_unknown_key_rejected(self):
+        result = self.handler.create_sphere({'radius': 5, 'depth': 10})
+        self._assert_unknown_key_error(result, 'depth')
+
+    def test_cone_unknown_key_rejected(self):
+        result = self.handler.create_cone({'radius1': 5, 'radius2': 0, 'height': 10, 'typo': 1})
+        self._assert_unknown_key_error(result, 'typo')
+
+    def test_torus_unknown_key_rejected(self):
+        result = self.handler.create_torus({'radius1': 10, 'radius2': 3, 'extra': 1})
+        self._assert_unknown_key_error(result, 'extra')
+
+    def test_wedge_unknown_key_rejected(self):
+        result = self.handler.create_wedge({'xmin': 0, 'bogus': 5})
+        self._assert_unknown_key_error(result, 'bogus')
+
+    def test_injected_operation_key_tolerated(self):
+        # dispatcher always forwards `operation` — must not trigger the unknown-key check
+        result = self.handler.create_box({'length': 10, 'width': 10, 'height': 10, 'operation': 'box'})
+        self.assertNotIn("unknown argument", result)
+
+    def test_injected_continuation_keys_tolerated(self):
+        result = self.handler.create_box({
+            'length': 10, 'width': 10, 'height': 10,
+            'operation': 'box', '_continue_selection': True, '_operation_id': 'abc123',
+        })
+        self.assertNotIn("unknown argument", result)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

Ships **freecad-mcp 5.11.0**. Headline: de-stale everything coupled to FreeCAD's version renumbering (the dev series jumped **1.2 → 26.3**, skipping 1.2), plus the fixes that have been queued on `dev` since 5.10.0.

Nothing in the renumber actually broke at runtime — the version parse reads `int(ver[0])` with no assumption that major is `1` — but several spots referenced the old numbering or the `v1-2` user-data path and were misleading or fragile going forward.

## Changes

**Version-renumber compatibility**
- **`AGENT-INSTALL.md`**: stop hardcoding `~/…/FreeCAD/v1-2/Mod`; derive the Mod dir from `FreeCAD.getUserAppDataDir()` so install stays correct across the renumber and any future version-stamped path change.
- **`freecad_mcp_handler.py`**: keep the CAM version gate — it still gates correctly because the renumber leapt over 1.2 (`(1,1,x) < (1,2,0) < (26,3,0)`) — but document *why*, and reword user-facing messages from "requires 1.2+" to capability terms (Path Toolbit API / weekly / 26.x).
- **`freecad_mcp_server.py`**: add weekly-build / 26.x `.app` bundle names to the macOS binary search; point the `headless_server.py` dev fallback at `v26-3` while keeping `v1-2` for a not-yet-migrated profile.
- **`server.json`**: sync version (was stale at 5.8.1) to match `pyproject`.

**Queued fixes (already on `dev` since 5.10.0)**
- `fix(primitives)`: reject unknown/misspelled arg keys instead of silently defaulting; also hardened `create_document` to refuse unsafe off-GUI-thread creation.
- `chore(docker)`: bump FreeCAD to 1.1.0.
- Dependabot: `mcp` 1.27.2 → 1.28.0, `pytest` → 9.1.1, `pip-audit` → 2.10.1.

**Test fix**
- The `create_document` hardening above left `test_create_fallback_no_server` asserting the old unsafe-fallback behavior. Updated it to assert the new contract (refuses without a GUI dispatcher; `newDocument` not called).

## Verification

Unit suite: **1096 passed** on the final tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)