### PR TITLE
ci: add Docker build check on PR, failure alert on docker-publish

### DIFF
--- a/.github/workflows/check-upstream-releases.yml
+++ b/.github/workflows/check-upstream-releases.yml
@@ -24,17 +24,28 @@ jobs:
           # Read pinned version from Dockerfile (single source of truth)
           CURRENT_1_1=$(grep '^ARG FREECAD_VERSION=' Dockerfile | cut -d= -f2)
 
-          # Get latest 1.1.x stable release
-          LATEST_1_1=$(gh api repos/FreeCAD/FreeCAD/releases --paginate --jq '.[] | select(.tag_name | test("^1\\.1\\.[0-9]+$")) | .tag_name' | head -1 | sed 's/^v//')
+          # Latest 1.1.x stable on GitHub (informational — this is upstream's
+          # release, not necessarily what we can actually install)
+          GH_LATEST_1_1=$(gh api repos/FreeCAD/FreeCAD/releases --paginate --jq '.[] | select(.tag_name | test("^1\\.1\\.[0-9]+$")) | .tag_name' | head -1 | sed 's/^v//')
 
-          # Get latest 1.2 pre-release
+          # Latest 1.2 pre-release (informational)
           LATEST_1_2=$(gh api repos/FreeCAD/FreeCAD/releases --jq '.[] | select(.prerelease) | select(.tag_name | test("^1\\.2")) | .tag_name' | head -1 | sed 's/^v//')
 
-          echo "latest_1_1=$LATEST_1_1" >> $GITHUB_OUTPUT
+          # Latest version actually published on conda-forge — this is what the
+          # Dockerfile installs (`micromamba create -c conda-forge freecad=...`),
+          # so it's the only version that's actually actionable right now.
+          # conda-forge routinely lags the GitHub release by weeks/months.
+          CONDA_LATEST_1_1=$(curl -s "https://api.anaconda.org/package/conda-forge/freecad" | jq -r '.latest_version')
+
+          echo "gh_latest_1_1=$GH_LATEST_1_1" >> $GITHUB_OUTPUT
           echo "current_1_1=$CURRENT_1_1" >> $GITHUB_OUTPUT
           echo "latest_1_2=$LATEST_1_2" >> $GITHUB_OUTPUT
+          echo "conda_latest_1_1=$CONDA_LATEST_1_1" >> $GITHUB_OUTPUT
 
-          if [ "$LATEST_1_1" != "$CURRENT_1_1" ] || [ -n "$LATEST_1_2" ]; then
+          # Only actionable if conda-forge has shipped something newer than
+          # what we're pinned to. A GitHub release conda-forge hasn't packaged
+          # yet is not something we can bump to.
+          if [ "$CONDA_LATEST_1_1" != "$CURRENT_1_1" ] || [ -n "$LATEST_1_2" ]; then
             echo "update_available=true" >> $GITHUB_OUTPUT
           fi
 
@@ -42,12 +53,53 @@ jobs:
         id: python_deps
         run: |
           python3 -m venv /tmp/dep-check
-          python3 -c "import tomllib; data=tomllib.load(open('pyproject.toml','rb')); [print(d) for d in data['project']['dependencies']]" > /tmp/project-deps.txt
+
+          # Names of this project's own direct dependencies (main + test extra).
+          # Anything else pip reports as "outdated" is transitive (pulled in by
+          # mcp/pydantic, etc.) or incidental to the venv (pip itself) — not
+          # something this repo pins or can act on directly.
+          python3 -c "
+          import re, tomllib
+          data = tomllib.load(open('pyproject.toml', 'rb'))
+          deps = list(data['project']['dependencies'])
+          for extra_deps in data['project'].get('optional-dependencies', {}).values():
+              deps.extend(extra_deps)
+          for d in deps:
+              name = re.split(r'[<>=!~\[; ]', d, maxsplit=1)[0]
+              print(name)
+          " > /tmp/direct-dep-names.txt
+
+          # Normalize for comparison (PyPI treats -/_/. as equivalent).
+          normalize() { tr 'A-Z_.' 'a-z--' ; }
+          normalize < /tmp/direct-dep-names.txt | sort -u > /tmp/direct-dep-names-normalized.txt
+
+          python3 -c "
+          import tomllib
+          data=tomllib.load(open('pyproject.toml','rb'))
+          [print(d) for d in data['project']['dependencies']]
+          " > /tmp/project-deps.txt
           /tmp/dep-check/bin/pip install -r /tmp/project-deps.txt -q
-          OUTDATED=$(/tmp/dep-check/bin/pip list --outdated --format=json | jq -r '.[] | "\(.name)==\(.latest_version)"' 2>/dev/null || echo "")
-          if [ -n "$OUTDATED" ]; then
+
+          OUTDATED=$(/tmp/dep-check/bin/pip list --outdated --format=json | jq -r '.[] | "\(.name)==\(.latest_version)"')
+
+          FILTERED=""
+          while IFS= read -r line; do
+            pkg=$(echo "$line" | cut -d= -f1 | normalize)
+            # Exclude pip itself unconditionally — it's not a project dependency,
+            # just whatever version happened to ship in this throwaway venv.
+            if [ "$pkg" = "pip" ]; then
+              continue
+            fi
+            if grep -qxF "$pkg" /tmp/direct-dep-names-normalized.txt; then
+              FILTERED="${FILTERED}${line}
+          "
+            fi
+          done <<< "$OUTDATED"
+          FILTERED=$(echo "$FILTERED" | sed '/^$/d')
+
+          if [ -n "$FILTERED" ]; then
             echo "outdated<<EOF" >> $GITHUB_OUTPUT
-            echo "$OUTDATED" >> $GITHUB_OUTPUT
+            echo "$FILTERED" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT
             echo "update_available=true" >> $GITHUB_OUTPUT
           fi
@@ -60,7 +112,8 @@ jobs:
         with:
           script: |
             const freecad_1_1_current = '${{ steps.freecad.outputs.current_1_1 }}';
-            const freecad_1_1_latest = '${{ steps.freecad.outputs.latest_1_1 }}';
+            const freecad_1_1_gh_latest = '${{ steps.freecad.outputs.gh_latest_1_1 }}';
+            const freecad_1_1_conda_latest = '${{ steps.freecad.outputs.conda_latest_1_1 }}';
             const freecad_1_2_latest = '${{ steps.freecad.outputs.latest_1_2 }}';
             const python_deps = `${{ steps.python_deps.outputs.outdated }}`;
 
@@ -68,8 +121,11 @@ jobs:
 
             if ('${{ steps.freecad.outputs.update_available }}' === 'true') {
               body += '## FreeCAD\n';
-              if (freecad_1_1_current !== freecad_1_1_latest) {
-                body += `### Stable (1.1.x)\n- Current: v${freecad_1_1_current}\n- Latest: v${freecad_1_1_latest}\n- **Action:** bump \`ARG FREECAD_VERSION=${freecad_1_1_latest}\` in \`Dockerfile\`\n\n`;
+              if (freecad_1_1_conda_latest !== freecad_1_1_current) {
+                body += `### Stable (1.1.x) — installable via conda-forge\n- Current: v${freecad_1_1_current}\n- Latest on conda-forge: v${freecad_1_1_conda_latest}\n- **Action:** bump \`ARG FREECAD_VERSION=${freecad_1_1_conda_latest}\` in \`Dockerfile\`\n\n`;
+              }
+              if (freecad_1_1_gh_latest !== freecad_1_1_conda_latest) {
+                body += `### FYI — GitHub release ahead of conda-forge\n- Latest GitHub release: v${freecad_1_1_gh_latest}\n- Latest on conda-forge: v${freecad_1_1_conda_latest}\n- **Not actionable yet:** the Dockerfile installs FreeCAD via conda-forge, which hasn't packaged this release. No action until the conda-forge feedstock catches up.\n\n`;
               }
               if (freecad_1_2_latest) {
                 body += `### Development (1.2-dev)\n- Latest pre-release: v${freecad_1_2_latest}\n- **Note:** CAM tools require 1.2+; all other tools work with 1.1.x stable\n\n`;
@@ -77,7 +133,7 @@ jobs:
             }
 
             if (python_deps.trim()) {
-              body += `## Python Dependencies\n\`\`\`\n${python_deps}\n\`\`\`\n\n`;
+              body += `## Python Dependencies\nDirect dependencies only (transitive deps and pip itself are excluded — they aren't pinned in \`pyproject.toml\` and aren't independently actionable here):\n\`\`\`\n${python_deps}\n\`\`\`\n\n`;
             }
 
             body += '**Note:** Review and test before upgrading. FreeCAD API may change between versions.';

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -1,0 +1,55 @@
+name: Docker Build Check
+
+# Build-only (no push, no registry credentials needed) validation that the
+# Dockerfile actually builds. Exists because docker-publish.yml only runs at
+# release time, only pushes (never just builds) and had no failure alerting
+# until 2026-07-13 -- a build-breaking change could sit undetected for weeks.
+# This runs on every PR that touches anything the image depends on, so a
+# broken Dockerfile fails at review time instead of at the next release.
+
+on:
+  push:
+    branches: [main, rewrite-core]
+    paths:
+      - 'Dockerfile'
+      - 'docker-entrypoint.sh'
+      - 'freecad_mcp_server.py'
+      - 'mcp_bridge_framing.py'
+      - 'AICopilot/**'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/docker-build-check.yml'
+      - '.github/workflows/docker-publish.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'docker-entrypoint.sh'
+      - 'freecad_mcp_server.py'
+      - 'mcp_bridge_framing.py'
+      - 'AICopilot/**'
+      - 'requirements.txt'
+      - 'pyproject.toml'
+      - '.github/workflows/docker-build-check.yml'
+      - '.github/workflows/docker-publish.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,14 @@
 name: Publish Docker Image
 
 on:
-  release:
-    types: [published]
+  # Triggers directly on the tag push (same trigger as release.yml), not on
+  # release.yml's `release: published` event: that event is created via
+  # softprops/action-gh-release using the default GITHUB_TOKEN, and GitHub
+  # doesn't cascade workflow triggers off GITHUB_TOKEN-authored events. This
+  # sidesteps that entirely by watching the tag push itself.
+  push:
+    tags:
+      - 'v[0-9]*'
   workflow_dispatch:
     inputs:
       tag:
@@ -33,8 +39,8 @@ jobs:
       - name: Determine image tags
         id: meta
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            VERSION="${{ github.event.release.tag_name }}"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            VERSION="${{ github.ref_name }}"
           else
             VERSION="${{ inputs.tag }}"
           fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   packages: write
+  issues: write
 
 jobs:
   docker:
@@ -56,3 +57,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Notify on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Docker publish failed for ${context.ref}`,
+              body: `The docker-publish workflow failed and did not push an updated image to ghcr.io.\n\nRun: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              labels: ['bug']
+            })

--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -50,11 +50,11 @@ The MCP bridge runs on the system Python (not FreeCAD's bundled Python).
 - **Linux:** `sudo apt install python3`
 - **Windows:** https://www.python.org/downloads/
 
-### 3. MCP Python package (required)
+### 3. MCP Python packages (required)
 
-The bridge depends on the `mcp` package.
+The bridge depends on the `mcp` and `mcp-events` packages.
 
-**Install:** `pip3 install mcp>=0.1.0`
+**Install:** `pip3 install mcp>=0.1.0 mcp-events>=0.1.0`
 
 ## Installation
 
@@ -90,7 +90,7 @@ renumber and any future change.
 ```bash
 mkdir -p ~/.freecad-mcp
 cp freecad_mcp_server.py mcp_bridge_framing.py ~/.freecad-mcp/
-pip3 install mcp>=0.1.0
+pip3 install mcp>=0.1.0 mcp-events>=0.1.0
 ```
 
 ### Step 4: Register as an MCP Server

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -6,7 +6,7 @@
 #                   list_freecad_instances enriched with active doc + window
 #                   title; startup banner shows handler version.
 
-__version__ = "5.11.0"
+__version__ = "5.11.1"
 
 # Minimum FreeCAD version required for CAM tools (the new Path Toolbit API).
 # Below this, cam_operations / cam_tools / cam_tool_controllers return a clean

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN micromamba create -p /opt/freecad -c conda-forge \
     && micromamba clean -a --yes
 
 # Install MCP bridge Python dependencies into the same env
-RUN micromamba run -p /opt/freecad pip install --no-cache-dir "mcp>=1.27.1"
+RUN micromamba run -p /opt/freecad pip install --no-cache-dir "mcp>=1.27.1" "mcp-events>=0.1.0"
 
 # Copy MCP server
 COPY freecad_mcp_server.py mcp_bridge_framing.py /opt/freecad-mcp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,12 @@ ARG FREECAD_VERSION=1.1.0
 
 USER root
 
-# Install FreeCAD via conda-forge (this is what the AppImages are built from)
+# Install FreeCAD via conda-forge (this is what the AppImages are built from).
+# conda-forge's freecad package doesn't pull in pip as a dependency -- install
+# it explicitly, since the next step needs it to install the MCP bridge deps.
 RUN micromamba create -p /opt/freecad -c conda-forge \
     freecad=${FREECAD_VERSION} \
+    pip \
     --yes \
     && micromamba clean -a --yes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freecad-mcp"
-version = "5.11.0"
+version = "5.11.1"
 description = "MCP server to control FreeCAD from Claude"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "mcp>=1.28.0",
+    "mcp>=1.28.1",
     "mcp-events>=0.1.0",
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # MCP Protocol (bridge dependency)
-mcp==1.28.0
+mcp==1.28.1
 mcp-events>=0.1.0
 
 # FreeCAD's Python bindings come with FreeCAD (PySide2/PySide6)

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.blwfish/freecad-mcp",
   "title": "FreeCAD MCP",
   "description": "Control FreeCAD from Claude — 3D modeling, PartDesign, CAM toolpaths, and more via 30+ tools.",
-  "version": "5.11.0",
+  "version": "5.11.1",
   "repository": {
     "url": "https://github.com/blwfish/freecad-mcp",
     "source": "github"


### PR DESCRIPTION
## Summary
Structural fix, not just today's individual bugs: everything that broke over the last two months (docker-publish's trigger, the repo permission, the missing mcp-events install, the missing pip) lived in the release/distribution path, which is exercised once every few weeks and had zero failure alerting -- unlike the actual code path (1096 unit tests on every push), which would have caught something this sloppy immediately.

- **`docker-build-check.yml`** (new): build-only (no push, no registry credentials) validation that the Dockerfile actually builds. Triggers on PR/push touching `Dockerfile`, `docker-entrypoint.sh`, `freecad_mcp_server.py`, `mcp_bridge_framing.py`, `AICopilot/**`, `requirements.txt`, `pyproject.toml`, or either Docker workflow file itself. Catches a broken build at review time instead of at the next release -- would have caught both the mcp-events gap and the pip gap immediately, at PR time, instead of two months later.
- **`docker-publish.yml`**: add a "Notify on failure" step matching `release.yml`'s existing pattern (opens a GitHub issue with a link to the failed run). This workflow had no alerting at all -- its one real failure (2026-05-15, permission_denied) sat unnoticed in the Actions tab for two months because nothing surfaced it.

## Test plan
- [x] Both workflow files parse cleanly (`yaml.safe_load`)
- [ ] This PR itself should trigger `docker-build-check.yml` (both workflow files are in its path filter) -- check the PR's checks tab for a live run

🤖 Generated with [Claude Code](https://claude.com/claude-code)