### PR TITLE
chore(review): establish tautology_sweep baseline (0 violations)

### DIFF
--- a/.claude-review/tautology_baseline.json
+++ b/.claude-review/tautology_baseline.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "note": "Grandfathered tautology-sweep violations (Stage-1 net). Run `tautology_sweep.py --root <repo> --update-baseline` to refresh after fixing or intentionally adding. The count may only fall: --check fails on any violation NOT listed here.",
+  "tautological_tests": []
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-review/tautology_baseline.json` (0 violations) via a standalone `tautology_sweep.py --update-baseline` run
- Prompted by discovering `/full-review`'s Phase 3 wasn't actually invoking the tautology sweep (fixed upstream in claude-journal `e305653`)

## Impact
Zero runtime/packaging impact — verified `.claude-review/` is never referenced by the Dockerfile's `COPY` statements, `pyproject.toml` has no packaging include list that would sweep it up, and no CI workflow reads this file yet. Repo-housekeeping only.

## Test plan
- [x] Confirmed genuinely clean (61 test files scanned under `tests/`), not a silent empty-scan result