### PR TITLE
ci+docs: bring main to parity with dev on release/install setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # mcp-publisher's github-oidc login -- no stored secret needed
 
 jobs:
   release:
@@ -31,6 +32,25 @@ jobs:
         with:
           body_path: RELEASE_NOTES.md
           tag_name: ${{ github.ref_name }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Publish to MCP Registry
+        run: |
+          # Pinned (not @latest) so a breaking mcp-publisher release can't
+          # silently change CI behavior -- bump deliberately, matching
+          # whatever version is in local use (see project_registry_
+          # distribution.md memory / `mcp-publisher --version` locally).
+          # `go install`'s cmd/publisher package produces a binary named
+          # "publisher", not "mcp-publisher" -- full path, not relying on
+          # actions/setup-go's PATH export, to keep this self-contained.
+          go install github.com/modelcontextprotocol/registry/cmd/publisher@v1.7.9
+          PUBLISHER="$(go env GOPATH)/bin/publisher"
+          "$PUBLISHER" login github-oidc
+          "$PUBLISHER" publish
 
       - name: Notify on failure
         if: failure()

--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -60,8 +60,11 @@ The bridge depends on the `mcp` and `mcp-events` packages.
 
 ### Step 1: Clone the repo
 
+Install from `main` — it's the stable branch releases are cut from. `dev` is
+where active work happens and can be left inconsistent between commits.
+
 ```bash
-git clone https://github.com/blwfish/freecad-mcp.git
+git clone -b main https://github.com/blwfish/freecad-mcp.git
 ```
 
 Clone location: wherever repos live on this system. `~/freecad-mcp` is a safe default.


### PR DESCRIPTION
- \`release.yml\`: main was missing the MCP Registry publish step that dev
  already has (mcp-publisher via github-oidc) — releases tagged off main
  were silently skipping the registry publish since tag-triggered workflows
  read from the tagged commit itself.
- \`AGENT-INSTALL.md\`: clone \`-b main\` explicitly rather than relying on
  main happening to already be the default branch.

Already pushed directly to the \`gitea\` mirror (that remote allows it);
opening this PR because GitHub's main requires one.