### PR TITLE
chore(ci): bump dev-weekly FreeCAD pin to weekly-2026.08.05

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
             # it belongs to the separate PR-only job below, on every push.
             pytest_args: "-m 'not cam and not real_document'"
           - slot: "dev-weekly"
-            tag: "weekly-2026.07.15"
+            tag: "weekly-2026.08.05"
             appimage: ""  # resolved by glob below
             pytest_args: "-m 'not real_document'"
 
@@ -112,7 +112,7 @@ jobs:
       - name: Set up FreeCAD AppImage
         uses: ./.github/actions/setup-freecad-appimage
         with:
-          tag: "weekly-2026.07.15"
+          tag: "weekly-2026.08.05"
           appimage: ""
           use-cache: 'true'
           install-gdb: 'true'


### PR DESCRIPTION
Closes #52.

Issue #52 (opened 2026-08-03) flagged `weekly-2026.07.29` as latest, but that's
now stale — `weekly-2026.08.05` was published 2026-08-05 and is the actual
latest weekly (verified against the FreeCAD/FreeCAD releases API, full asset
set including the Linux x86_64 AppImage CI needs).

Past dev-weekly bumps have broken CI-relevant handler code before (see
KNOWN_ISSUES.md's `create_tool`/`ToolBit.from_dict()` regression and the
`libCoin.so` expat-symbol-collision SIGSEGV investigation from the 04.01→07.15
bump). This PR exists specifically to get a real integration-test run against
the new build before merging — not a blind pin bump.

## Test plan
- [x] Verified `weekly-2026.08.05` is a real, complete release (not just a tag)
- [ ] `FreeCAD dev-weekly` integration job passes against the new build
- [ ] `real-document-regression` job passes against the new build