### PR TITLE
Release 7.2.0

### DIFF
--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -22,8 +22,15 @@
 #                   to mcp 2.0's constructor-based handler registration. Added
 #                   recompute/contains_point bridge operations and a cached,
 #                   auditable GitHub release update check.
+# Version: 7.2.0 - macOS bridge reliability: FreeCADCmd/headless_server.py
+#                   discovery fixed for documented install locations;
+#                   screenshot capture consolidated into the bridge and
+#                   cropped to FreeCAD's window; reload_modules fixed to
+#                   import freecad_mcp_handler under its real name. Docker
+#                   image bumped to FreeCAD 1.1.3 and fixed a broken socket
+#                   wait that made every container run time out.
 
-__version__ = "7.1.0"
+__version__ = "7.2.0"
 
 # Minimum FreeCAD version required for CAM tools (the new Path Toolbit API).
 # Below this, cam_operations / cam_tools / cam_tool_controllers return a clean

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -1800,8 +1800,15 @@ class FreeCADSocketServer:
             # Reload freecad_mcp_handler.py itself and rebind _execute_tool_inner
             # so dispatch-map changes (new tools added to generic_dispatch_map)
             # take effect without a FreeCAD restart.
-            import AICopilot.freecad_mcp_handler as _self_mod
-            new_self = _reload('AICopilot.freecad_mcp_handler', _self_mod)
+            #
+            # Imported under its bare name, not AICopilot.freecad_mcp_handler --
+            # InitGui.py appends the AICopilot directory itself to sys.path and
+            # does `from freecad_mcp_handler import ...`, so that's the name
+            # it's actually registered under in sys.modules. The AICopilot
+            # entry that does exist is just the addon's Init.py/workbench
+            # registration, not a real package containing this module.
+            import freecad_mcp_handler as _self_mod
+            new_self = _reload('freecad_mcp_handler', _self_mod)
             # Rebind all dispatch methods so routing changes take effect immediately.
             # _execute_tool_inner calls self._dispatch_view_control etc., so those
             # must be rebound too or the old routing (without new operations) runs.

--- a/AICopilot/handlers/view_ops.py
+++ b/AICopilot/handlers/view_ops.py
@@ -23,27 +23,6 @@ _FACE_THRESH_HIGH  = 80_000   # above this: cap at 640x480
 _FACE_THRESH_HUGE  = 200_000  # above this: cap at 400x300
 
 
-def _read_png_dimensions(path):
-    """Read a PNG's actual width/height from its IHDR chunk, without a
-    Pillow dependency. Returns None if the file isn't a well-formed PNG.
-
-    Needed because macOS `screencapture -x` (no -R region flag) captures
-    the entire screen at its native resolution — never the caller's
-    requested width/height — so echoing the request back as if it were
-    the capture's real dimensions was simply wrong metadata.
-    """
-    import struct
-    try:
-        with open(path, "rb") as f:
-            header = f.read(24)
-        if len(header) < 24 or header[:8] != b'\x89PNG\r\n\x1a\n':
-            return None
-        width, height = struct.unpack('>II', header[16:24])
-        return width, height
-    except Exception:
-        return None
-
-
 def _estimate_scene_faces() -> int:
     """Count total visible faces across all visible objects in the active document."""
     doc = FreeCAD.ActiveDocument
@@ -236,17 +215,21 @@ class ViewOpsHandler(BaseHandler):
 
         MUST run on the GUI thread (dispatch layer handles this).
 
-        On macOS, uses the system `screencapture` command as the primary method.
-        This avoids the saveImage() deadlock where CoinGL needs the Qt event loop
-        to pump the OpenGL render, but saveImage() IS on the GUI thread, so the
-        event loop can't run — causing a permanent hang that crashes FreeCAD.
+        On macOS, the actual capture happens in the bridge process
+        (freecad_mcp_server.py's Darwin-specific `view_control` screenshot
+        shortcut), not here -- it crops to FreeCAD's window and never touches
+        this (GUI-adjacent) thread or requires FreeCAD's own Screen Recording
+        permission. The Darwin branch below is a tripwire, not a fallback: if
+        it's ever reached for a GUI instance, that shortcut was bypassed.
 
-        Falls back to saveImage() on non-macOS platforms or if screencapture fails.
+        Uses saveImage() on non-macOS platforms (and, via the guards below,
+        correctly refuses on any headless instance regardless of platform,
+        which is the one case where this handler is legitimately reached
+        without the bridge-side shortcut having run first).
         """
         import tempfile
         import os
         import base64
-        import subprocess
 
         req_width = args.get("width", 800)
         req_height = args.get("height", 600)
@@ -281,49 +264,24 @@ class ViewOpsHandler(BaseHandler):
             with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
                 tmp_path = f.name
 
-            # ── macOS: screencapture (subprocess, runs on socket thread) ─────────
+            # ── macOS tripwire — do NOT fall through to saveImage() below ────────
+            # saveImage() deadlocks the GUI thread on macOS (it needs the Qt
+            # event loop to pump the OpenGL render, but we ARE the GUI thread).
+            # The bridge-side shortcut is instance-aware and only steps aside
+            # for headless targets (already handled above, before this point),
+            # so a GUI macOS instance reaching here means that shortcut didn't
+            # run -- a bridge bug, a non-standard MCP client, or take_screenshot()
+            # called directly (e.g. via execute_python). Fail loudly rather than
+            # silently regressing into the deadlock.
             if platform.system() == "Darwin":
-                # -x  = suppress shutter sound
-                # no -w/-i = capture entire screen (FreeCAD visible on screen)
-                proc = subprocess.run(
-                    ["screencapture", "-x", tmp_path],
-                    timeout=10,
-                    capture_output=True,
-                )
-                stderr_text = proc.stderr.decode(errors="replace") if proc.stderr else ""
-                if proc.returncode == 0 and os.path.getsize(tmp_path) > 0:
-                    with open(tmp_path, "rb") as f:
-                        image_data = base64.b64encode(f.read()).decode("utf-8")
-                    # screencapture -x (no -R region flag) captures the
-                    # entire screen at its native resolution, never the
-                    # caller's requested width/height — echoing the
-                    # request back as if it were the capture's real
-                    # dimensions was simply wrong metadata. Fall back to
-                    # the request only if the PNG header can't be parsed
-                    # (should not happen for a real screencapture output,
-                    # but must not crash a successful capture over it).
-                    actual_dims = _read_png_dimensions(tmp_path)
-                    actual_width, actual_height = actual_dims if actual_dims else (req_width, req_height)
-                    return json.dumps({
-                        "success": True,
-                        "image_data": image_data,
-                        "mime_type": "image/png",
-                        "width": actual_width,
-                        "height": actual_height,
-                        "method": "screencapture",
-                    })
-                # screencapture failed — do NOT fall through to saveImage on macOS.
-                # saveImage() deadlocks the GUI thread (it needs the Qt event loop to
-                # pump the OpenGL render, but we ARE the GUI thread).
-                # Most likely cause: FreeCAD lacks Screen Recording permission.
-                # Grant it in: System Settings → Privacy & Security → Screen Recording
                 return json.dumps({
                     "success": False,
                     "error": (
-                        f"screencapture failed (rc={proc.returncode}). "
-                        "FreeCAD likely needs Screen Recording permission: "
-                        "System Settings → Privacy & Security → Screen Recording → enable FreeCAD. "
-                        f"stderr: {stderr_text[:300]}"
+                        "macOS screenshots are handled by the MCP bridge process "
+                        "(freecad_mcp_server.py), not FreeCAD itself. Reaching this "
+                        "code path for a GUI instance means that shortcut was "
+                        "bypassed -- call the view_control screenshot operation "
+                        "normally rather than invoking take_screenshot() directly."
                     ),
                 })
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # On Apple Silicon: docker build --platform linux/amd64 -t freecad-mcp .
 FROM mambaorg/micromamba:latest
 
-ARG FREECAD_VERSION=1.1.0
+ARG FREECAD_VERSION=1.1.3
 
 USER root
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 set -e
 
 SOCKET=/tmp/freecad_mcp.sock
+export FREECAD_MCP_SOCKET="$SOCKET"
 
 # Start FreeCAD headless socket server in the background
 "${FREECAD_MCP_FREECAD_BIN}" /opt/freecad-mcp/AICopilot/headless_server.py &

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -627,6 +627,47 @@ def _find_headless_script() -> str | None:
     return None
 
 
+def _get_freecad_window_bounds(timeout: float = 5) -> tuple[int, int, int, int] | None:
+    """Return (x, y, w, h) of FreeCAD's frontmost window in screen coordinates
+    (as `screencapture -R` expects), via System Events, or None if FreeCAD
+    isn't running, its window can't be found, or Accessibility automation
+    isn't permitted for this process.
+
+    Used so the bridge-process screenshot shortcut (Darwin `view_control`
+    screenshot handling below) captures FreeCAD's viewport specifically,
+    instead of whatever happens to be frontmost on the physical screen.
+
+    The process name System Events sees depends on how FreeCAD was launched:
+    the official .app bundle's launcher registers as "FreeCAD", but running
+    the inner Contents/Resources/bin/freecad binary directly (e.g. outside
+    LaunchServices) registers as "freecad" instead -- try both.
+    """
+    for proc_name in ("FreeCAD", "freecad"):
+        script = (
+            f'tell application "System Events" to tell process "{proc_name}" '
+            'to get {position, size} of front window'
+        )
+        try:
+            proc = subprocess.run(
+                ["osascript", "-e", script],
+                timeout=timeout,
+                capture_output=True,
+                text=True,
+            )
+            if proc.returncode != 0:
+                continue
+            parts = [int(p.strip()) for p in proc.stdout.strip().split(",")]
+            if len(parts) != 4:
+                continue
+            x, y, w, h = parts
+            if w <= 0 or h <= 0:
+                continue
+            return x, y, w, h
+        except Exception:
+            continue
+    return None
+
+
 def _read_launch_log_tail(path: str, max_bytes: int = 4000) -> str:
     """Best-effort tail of a spawned FreeCAD process's captured stdout/stderr.
 
@@ -2520,24 +2561,61 @@ async def main():
         # macOS screenshot: run screencapture in the bridge process (which inherits
         # Screen Recording permission from the terminal), never touching FreeCAD's
         # GUI thread or requiring FreeCAD to have its own TCC permission.
+        #
+        # Cropped to FreeCAD's own window (via -R, using bounds from System
+        # Events) rather than the whole screen -- a plain `-x` full-screen
+        # capture returns whatever's frontmost, which is very often *not*
+        # FreeCAD (the caller's IDE/terminal, in the typical agent workflow),
+        # ignores the caller's requested width/height entirely, and is a
+        # privacy concern (captures the whole desktop, not just the
+        # viewport). Falls back to full-screen if the window lookup fails
+        # (e.g. FreeCAD not running, or Accessibility permission not
+        # granted), so screenshot still works, just less precisely targeted.
         elif (name == "view_control"
               and (arguments or {}).get("operation") == "screenshot"
               and platform.system() == "Darwin"):
             import tempfile, base64 as _b64
+            args = arguments or {}
+            req_width = args.get("width", 800)
+            req_height = args.get("height", 600)
             tmp_path = None
             try:
                 with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
                     tmp_path = f.name
-                proc = subprocess.run(
-                    ["screencapture", "-x", tmp_path],
-                    timeout=10, capture_output=True,
-                )
+
+                bounds = _get_freecad_window_bounds()
+                cmd = ["screencapture", "-x"]
+                note = None
+                if bounds:
+                    x, y, w, h = bounds
+                    cmd += ["-R", f"{x},{y},{w},{h}"]
+                else:
+                    note = ("Could not locate FreeCAD's window (via System Events); "
+                             "captured the full screen instead. If unexpected, check "
+                             "Accessibility permission for the bridge's terminal/app in "
+                             "System Settings -> Privacy & Security -> Accessibility.")
+                cmd.append(tmp_path)
+
+                proc = subprocess.run(cmd, timeout=10, capture_output=True)
                 if proc.returncode == 0 and os.path.getsize(tmp_path) > 0:
+                    # Resize toward the requested dimensions -- both to honor
+                    # width/height (previously silently ignored) and to keep
+                    # the payload well clear of any transport size limit.
+                    # sips is a stock macOS tool; failure here just leaves
+                    # the capture at its native size rather than losing it.
+                    subprocess.run(
+                        ["sips", "-z", str(req_height), str(req_width), tmp_path],
+                        timeout=10, capture_output=True,
+                    )
                     with open(tmp_path, "rb") as f:
                         image_data = _b64.b64encode(f.read()).decode("utf-8")
-                    return [types.ImageContent(
+                    content: list = []
+                    if note:
+                        content.append(types.TextContent(type="text", text=json.dumps({"note": note})))
+                    content.append(types.ImageContent(
                         type="image", data=image_data, mimeType="image/png"
-                    )]
+                    ))
+                    return content
                 err = proc.stderr.decode(errors="replace")[:200]
                 return [types.TextContent(type="text", text=json.dumps({
                     "error": f"screencapture failed (rc={proc.returncode}): {err}"

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -487,6 +487,24 @@ class _BridgeCtx:
 _ctx = _BridgeCtx()
 
 
+def _current_target_is_headless() -> bool:
+    """True if the currently-resolved FreeCAD target is headless, or can't
+    be resolved at all (no live instance, or an ambiguous multi-instance
+    state). Used to gate the Darwin screenshot shortcut below so it only
+    ever fires for a real GUI instance -- never blindly for a headless
+    target (no window exists to capture) or when no instance is confirmed
+    live, both of which it would otherwise screenshot the desktop for
+    regardless, unrelated to what was actually asked for.
+    """
+    sock_path, _err = _ctx.resolve_target()
+    if not sock_path:
+        return True
+    for entry in _ctx.list_all():
+        if entry.get("socket_path") == sock_path:
+            return bool(entry.get("headless"))
+    return True
+
+
 # =============================================================================
 # FreeCADCmd / headless_server.py discovery helpers
 # =============================================================================
@@ -2571,9 +2589,17 @@ async def main():
         # viewport). Falls back to full-screen if the window lookup fails
         # (e.g. FreeCAD not running, or Accessibility permission not
         # granted), so screenshot still works, just less precisely targeted.
+        #
+        # Gated on the targeted instance actually being a GUI one: a headless
+        # instance has no window at all, so this shortcut steps aside for it
+        # and falls through to the generic dispatch below, which routes to
+        # FreeCAD's own take_screenshot() -- its existing GuiUp guard reports
+        # "headless mode" correctly, without this shortcut blindly
+        # screenshotting the desktop regardless of what was actually running.
         elif (name == "view_control"
               and (arguments or {}).get("operation") == "screenshot"
-              and platform.system() == "Darwin"):
+              and platform.system() == "Darwin"
+              and not _current_target_is_headless()):
             import tempfile, base64 as _b64
             args = arguments or {}
             req_width = args.get("width", 800)

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -5,6 +5,7 @@ Smart dispatchers aligned with FreeCAD workbench structure for optimal Claude Co
 """
 
 import asyncio
+import glob
 import json
 import os
 import re
@@ -496,7 +497,7 @@ def _find_freecadcmd() -> str | None:
     Search order:
       1. FREECAD_MCP_FREECAD_BIN env var (explicit override)
       2. shutil.which for common binary names
-      3. macOS app bundle locations
+      3. macOS app bundle locations (globbed, any "FreeCAD*.app")
       4. Linux/common system paths
     """
     override = os.environ.get("FREECAD_MCP_FREECAD_BIN")
@@ -508,14 +509,16 @@ def _find_freecadcmd() -> str | None:
         if path:
             return path
 
-    mac_candidates = [
-        "/Applications/FreeCAD.app/Contents/MacOS/FreeCADCmd",
-        "/Applications/FreeCAD 1.0.app/Contents/MacOS/FreeCADCmd",
-        "/Applications/FreeCAD 1.1.app/Contents/MacOS/FreeCADCmd",
-        "/Applications/FreeCAD 1.2.app/Contents/MacOS/FreeCADCmd",
-        # Weekly / renumbered (26.x) builds ship under these bundle names
-        "/Applications/FreeCAD weekly-builds.app/Contents/MacOS/FreeCADCmd",
-        "/Applications/FreeCAD 26.app/Contents/MacOS/FreeCADCmd",
+    # Official builds put the real binaries under Contents/Resources/bin/
+    # (lowercase); Contents/MacOS/ there is just a launcher stub. Some
+    # alternate/older layouts do put a console binary at Contents/MacOS/
+    # directly, so probe both. Glob the bundle name itself since it varies
+    # by version ("FreeCAD.app", "FreeCAD 1.1.app", "FreeCAD 26.app", ...).
+    mac_candidates = []
+    for bundle in sorted(glob.glob("/Applications/FreeCAD*.app")):
+        mac_candidates.append(os.path.join(bundle, "Contents", "Resources", "bin", "freecadcmd"))
+        mac_candidates.append(os.path.join(bundle, "Contents", "MacOS", "FreeCADCmd"))
+    mac_candidates += [
         # Local build (FC-clone)
         os.path.expanduser("~/Documents/FC-clone/build/release/bin/FreeCADCmd"),
         "/Volumes/Files/claude/FC-clone/build/release/bin/FreeCADCmd",
@@ -576,7 +579,11 @@ def _find_headless_script() -> str | None:
       1. FREECAD_MCP_MODULE_DIR env var / headless_server.py
       2. Alongside the bridge script (for dev workflows)
       3. ~/.freecad-mcp/ (standard install)
-      4. Known FreeCAD addon paths from MEMORY.md
+      4. FreeCAD's own per-user Mod dir (globbed, since the version-stamped
+         component -- v1-1, v1-2, v26-3, ... -- renumbers across releases),
+         same directory AGENT-INSTALL.md has the caller resolve via
+         FreeCAD.getUserAppDataDir()
+      5. Known addon paths from MEMORY.md (legacy fallback for this dev box)
     """
     override_dir = os.environ.get("FREECAD_MCP_MODULE_DIR")
     if override_dir:
@@ -590,9 +597,25 @@ def _find_headless_script() -> str | None:
         os.path.join(bridge_dir, "AICopilot", "headless_server.py"),
         # Standard install
         os.path.expanduser("~/.freecad-mcp/AICopilot/headless_server.py"),
-        # Known addon paths (from MEMORY.md). The version-stamped component
-        # follows FreeCAD's renumbering (v1-2 -> v26-3); keep both so a freshly
-        # migrated profile and a legacy one both resolve.
+    ]
+
+    system = platform.system()
+    if system == "Darwin":
+        mod_glob = os.path.expanduser(
+            "~/Library/Application Support/FreeCAD/*/Mod/AICopilot/headless_server.py"
+        )
+        candidates += sorted(glob.glob(mod_glob))
+    elif system == "Windows":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            mod_glob = os.path.join(appdata, "FreeCAD", "*", "Mod", "AICopilot", "headless_server.py")
+            candidates += sorted(glob.glob(mod_glob))
+    else:
+        mod_glob = os.path.expanduser("~/.local/share/FreeCAD/*/Mod/AICopilot/headless_server.py")
+        candidates += sorted(glob.glob(mod_glob))
+
+    candidates += [
+        # Known addon paths (from MEMORY.md) -- legacy fallback for this dev box.
         "/Volumes/Files/claude/FreeCAD-prefs/Mod/AICopilot/headless_server.py",
         "/Volumes/Files/claude/FreeCAD-prefs/v26-3/Mod/AICopilot/headless_server.py",
         "/Volumes/Files/claude/FreeCAD-prefs/v1-2/Mod/AICopilot/headless_server.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freecad-mcp"
-version = "7.1.0"
+version = "7.2.0"
 description = "MCP server to control FreeCAD from Claude"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.blwfish/freecad-mcp",
   "title": "FreeCAD MCP",
   "description": "Control FreeCAD from Claude — 3D modeling, PartDesign, CAM toolpaths, and more via 30+ tools.",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "repository": {
     "url": "https://github.com/blwfish/freecad-mcp",
     "source": "github"

--- a/tests/unit/test_instance_manager.py
+++ b/tests/unit/test_instance_manager.py
@@ -222,6 +222,33 @@ class TestFindFreecadCmd:
         # May still find a Mac app bundle; just ensure it doesn't crash
         assert result is None or os.path.isfile(result)
 
+    def test_finds_official_bundle_resources_bin_layout(self, bridge, monkeypatch, tmp_path):
+        """Official macOS builds put the real binary under Contents/Resources/bin/
+        (lowercase 'freecadcmd'); Contents/MacOS/ there is just a launcher stub.
+        Regression test for issue #58."""
+        monkeypatch.delenv("FREECAD_MCP_FREECAD_BIN", raising=False)
+        bundle = tmp_path / "FreeCAD.app"
+        real_bin = bundle / "Contents" / "Resources" / "bin" / "freecadcmd"
+        real_bin.parent.mkdir(parents=True)
+        real_bin.touch()
+        (bundle / "Contents" / "MacOS" / "FreeCAD").parent.mkdir(parents=True)
+        (bundle / "Contents" / "MacOS" / "FreeCAD").touch()  # launcher stub, not FreeCADCmd
+
+        with patch("shutil.which", return_value=None), \
+             patch.object(bridge.glob, "glob", return_value=[str(bundle)]):
+            result = bridge._find_freecadcmd()
+        assert result == str(real_bin)
+
+    def test_globs_versioned_app_bundle_names(self, bridge, monkeypatch, tmp_path):
+        """Bundle names vary by version ('FreeCAD 1.1.app', 'FreeCAD 26.app', ...);
+        the candidate list should come from a glob, not a fixed enumeration."""
+        monkeypatch.delenv("FREECAD_MCP_FREECAD_BIN", raising=False)
+        with patch("shutil.which", return_value=None), \
+             patch.object(bridge.glob, "glob") as glob_mock:
+            glob_mock.return_value = []
+            bridge._find_freecadcmd()
+        glob_mock.assert_any_call("/Applications/FreeCAD*.app")
+
 
 # ===========================================================================
 # _find_freecad_gui
@@ -277,6 +304,36 @@ class TestFindHeadlessScript:
         assert result is not None
         assert result.endswith("headless_server.py")
         assert os.path.isfile(result)
+
+    def test_darwin_globs_versioned_user_mod_dir(self, bridge, monkeypatch, tmp_path):
+        """FreeCAD's per-user Mod dir is version-stamped (v1-1, v1-2, v26-3, ...)
+        and is exactly what AGENT-INSTALL.md has the caller resolve via
+        FreeCAD.getUserAppDataDir(). Regression test for issue #58."""
+        monkeypatch.delenv("FREECAD_MCP_MODULE_DIR", raising=False)
+        mod_script = tmp_path / "v1-2" / "Mod" / "AICopilot" / "headless_server.py"
+        mod_script.parent.mkdir(parents=True)
+        mod_script.touch()
+
+        monkeypatch.setattr(bridge.platform, "system", lambda: "Darwin")
+        monkeypatch.setattr(bridge.glob, "glob", lambda pattern: [str(mod_script)])
+        # Force every higher-priority candidate (dev sibling, ~/.freecad-mcp) to miss
+        # so we can prove the new Mod-dir glob candidate is actually reachable.
+        monkeypatch.setattr("os.path.isfile", lambda p: p == str(mod_script))
+
+        result = bridge._find_headless_script()
+        assert result == str(mod_script)
+
+    def test_darwin_globs_user_mod_dir_pattern(self, bridge, monkeypatch):
+        """The glob pattern itself should target ~/Library/Application Support/
+        FreeCAD/*/Mod/AICopilot, not a fixed set of hardcoded version strings."""
+        monkeypatch.delenv("FREECAD_MCP_MODULE_DIR", raising=False)
+        monkeypatch.setattr(bridge.platform, "system", lambda: "Darwin")
+        with patch.object(bridge.glob, "glob", return_value=[]) as glob_mock:
+            bridge._find_headless_script()
+        expected = os.path.expanduser(
+            "~/Library/Application Support/FreeCAD/*/Mod/AICopilot/headless_server.py"
+        )
+        glob_mock.assert_any_call(expected)
 
 
 # ===========================================================================

--- a/tests/unit/test_view_ops_screenshot.py
+++ b/tests/unit/test_view_ops_screenshot.py
@@ -1,12 +1,15 @@
 """
 Tests for ViewOpsHandler.take_screenshot()
 
-Covers both the saveImage() code path (non-macOS) and the handler-side
-Darwin/screencapture path (M7/M8). Note there is also a SEPARATE
-screencapture implementation in freecad_mcp_server.py (the bridge process)
-that intercepts view_control screenshot calls before they'd reach this
-handler on a live macOS deployment — that path doesn't claim width/height
-at all, so it doesn't share M7's bug, and is not covered by this file.
+Covers the saveImage() code path (non-macOS) and this handler's Darwin
+guards/tripwire. The actual macOS capture lives entirely in
+freecad_mcp_server.py (the bridge process) -- its view_control screenshot
+shortcut is instance-aware (steps aside for headless targets) and crops to
+FreeCAD's window; that logic is not covered by this file. This handler's
+own Darwin branch only handles the headless/no-document guards (reached
+when the bridge steps aside) and a loud failure if a GUI instance ever
+reaches this code path directly, meaning the bridge-side shortcut was
+bypassed.
 """
 
 import base64
@@ -209,105 +212,52 @@ class TestHeadlessScreenshot:
 
 
 # ---------------------------------------------------------------------------
-# Darwin / screencapture path (M7, M8)
+# Darwin path (M7, M8, and the bridge-side consolidation that followed)
 # ---------------------------------------------------------------------------
 
 class TestDarwinScreenshot:
-    """The non-Darwin branch above always had a GuiUp guard; the Darwin
-    branch was missing it (M8), and separately claimed the caller's
-    requested width/height as if they were the actual capture dimensions,
-    even though `screencapture -x` (no -R region flag) always captures the
-    whole screen at native resolution (M7)."""
-
-    def _mock_screencapture_writes(self, png_bytes):
-        def _run(cmd, timeout=None, capture_output=None):
-            # cmd is ["screencapture", "-x", tmp_path]
-            with open(cmd[2], "wb") as f:
-                f.write(png_bytes)
-            proc = MagicMock()
-            proc.returncode = 0
-            proc.stderr = b""
-            return proc
-        return _run
+    """Actual macOS capture now happens in the bridge process
+    (freecad_mcp_server.py's view_control screenshot shortcut), not here —
+    it crops to FreeCAD's window instead of the whole screen and never
+    touches this thread. This handler still owns the headless/no-document
+    guards (needed when the bridge steps aside for a headless target), and
+    fails loudly rather than silently falling back to saveImage() -- which
+    deadlocks the GUI thread on macOS -- if a GUI instance ever reaches it
+    directly, meaning the bridge-side shortcut was bypassed."""
 
     def test_headless_darwin_screenshot_refused(self):
         """M8: a headless macOS instance (GuiUp=False) must refuse before
-        ever invoking screencapture — previously it would photograph
+        reaching the Darwin tripwire below — previously it would photograph
         whatever's on the physical screen, unrelated to FreeCAD, and
         report success."""
-        with patch(_FREECAD_PATH) as fc, patch(_PLATFORM_PATH) as plat, \
-             patch("subprocess.run") as mock_run:
+        with patch(_FREECAD_PATH) as fc, patch(_PLATFORM_PATH) as plat:
             fc.GuiUp = False
             fc.ActiveDocument = MagicMock()  # a document can exist without a GUI
             plat.system.return_value = "Darwin"
             result = json.loads(make_handler().take_screenshot({}))
         assert result["success"] is False
         assert "headless" in result["error"].lower()
-        mock_run.assert_not_called()
 
     def test_darwin_no_active_document_refused(self):
-        with patch(_FREECAD_PATH) as fc, patch(_PLATFORM_PATH) as plat, \
-             patch("subprocess.run") as mock_run:
+        with patch(_FREECAD_PATH) as fc, patch(_PLATFORM_PATH) as plat:
             fc.GuiUp = True
             fc.ActiveDocument = None
             plat.system.return_value = "Darwin"
             result = json.loads(make_handler().take_screenshot({}))
         assert result["success"] is False
         assert "No active document" in result["error"]
-        mock_run.assert_not_called()
 
-    def test_reports_actual_captured_dimensions_not_requested(self):
-        """M7: the caller requests 1920x1080, but the mocked
-        `screencapture` writes the 1x1 PNG_1x1 fixture (standing in for
-        the real screen's actual native resolution) — the response must
-        report the file's real dimensions, not echo the request."""
-        with patch(_FREECAD_PATH) as fc, patch(_PLATFORM_PATH) as plat, \
-             patch("subprocess.run", side_effect=self._mock_screencapture_writes(PNG_1x1)):
-            fc.GuiUp = True
-            fc.ActiveDocument = MagicMock()
-            plat.system.return_value = "Darwin"
-            result = json.loads(make_handler().take_screenshot({"width": 1920, "height": 1080}))
-        assert result["success"] is True
-        assert result["width"] == 1
-        assert result["height"] == 1
-
-    def test_screencapture_failure_returns_error_not_fallback(self):
+    def test_gui_instance_hitting_handler_directly_fails_loudly(self):
+        """A GUI macOS instance reaching this handler at all means the
+        bridge-side shortcut was bypassed. It must fail with an explicit
+        error, never silently fall through to saveImage() (GUI-thread
+        deadlock) or attempt its own screencapture."""
         with patch(_FREECAD_PATH) as fc, patch(_PLATFORM_PATH) as plat, \
              patch("subprocess.run") as mock_run:
             fc.GuiUp = True
             fc.ActiveDocument = MagicMock()
             plat.system.return_value = "Darwin"
-            proc = MagicMock()
-            proc.returncode = 1
-            proc.stderr = b"not authorized"
-            mock_run.return_value = proc
             result = json.loads(make_handler().take_screenshot({}))
         assert result["success"] is False
-        assert "screencapture failed" in result["error"]
-
-
-class TestReadPngDimensions:
-    """_read_png_dimensions is the module-level helper M7's fix depends on
-    for real (not requested) capture dimensions."""
-
-    def test_reads_1x1_fixture_correctly(self, tmp_path):
-        from handlers.view_ops import _read_png_dimensions
-        p = tmp_path / "test.png"
-        p.write_bytes(PNG_1x1)
-        assert _read_png_dimensions(str(p)) == (1, 1)
-
-    def test_non_png_file_returns_none(self, tmp_path):
-        from handlers.view_ops import _read_png_dimensions
-        p = tmp_path / "not_a_png.png"
-        p.write_bytes(b"not a real png file at all, just text")
-        assert _read_png_dimensions(str(p)) is None
-
-    def test_missing_file_returns_none(self):
-        from handlers.view_ops import _read_png_dimensions
-        assert _read_png_dimensions("/nonexistent/path/to/nothing.png") is None
-
-    def test_truncated_header_returns_none(self, tmp_path):
-        from handlers.view_ops import _read_png_dimensions
-        p = tmp_path / "truncated.png"
-        p.write_bytes(PNG_1x1[:10])  # PNG signature but no IHDR chunk
-        assert _read_png_dimensions(str(p)) is None
+        assert "bridge process" in result["error"].lower()
+        mock_run.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ wheels = [
 
 [[package]]
 name = "freecad-mcp"
-version = "7.1.0"
+version = "7.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Summary
- Docker: bump FreeCAD 1.1.0 -> 1.1.3; fix docker-entrypoint.sh never exporting `FREECAD_MCP_SOCKET`, which made every container run time out waiting on a socket path the server never actually used (closes #59)
- macOS bridge: fix FreeCADCmd/headless_server.py discovery for documented install locations
- macOS bridge: consolidate screenshot capture into the bridge, crop to FreeCAD's window
- Fix `reload_modules` importing `freecad_mcp_handler` under its real name
- Version bump: 7.1.0 -> 7.2.0 (`pyproject.toml`, `server.json`, `AICopilot/freecad_mcp_handler.py`, `uv.lock`)

## Test plan
- [x] `.venv/bin/python -m pytest -q` — 1757 passed
- [x] Docker image built and verified locally: `FreeCAD.Version()` reports 1.1.3; socket now appears at the fixed `/tmp/freecad_mcp.sock` path while the container runs (previously always exited 1 after a 60s timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)