### PR TITLE
Release 7.3.0

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,11 +19,11 @@ jobs:
             appimage: "FreeCAD_1.1.1-Linux-x86_64-py311.AppImage"
             # real_document is excluded here too (not just dev-weekly) --
             # it belongs to the separate PR-only job below, on every push.
-            pytest_args: "-m 'not cam and not real_document'"
+            pytest_args: "-m 'not cam and not real_document and not fc_tools'"
           - slot: "dev-weekly"
             tag: "weekly-2026.08.20"
             appimage: ""  # resolved by glob below
-            pytest_args: "-m 'not real_document'"
+            pytest_args: "-m 'not real_document and not fc_tools'"
 
     name: "FreeCAD ${{ matrix.slot }}"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,7 +21,7 @@ jobs:
             # it belongs to the separate PR-only job below, on every push.
             pytest_args: "-m 'not cam and not real_document'"
           - slot: "dev-weekly"
-            tag: "weekly-2026.08.05"
+            tag: "weekly-2026.08.20"
             appimage: ""  # resolved by glob below
             pytest_args: "-m 'not real_document'"
 

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -29,8 +29,19 @@
 #                   import freecad_mcp_handler under its real name. Docker
 #                   image bumped to FreeCAD 1.1.3 and fixed a broken socket
 #                   wait that made every container run time out.
+# Version: 7.3.0 - execute_python() now surfaces FreeCAD Console warnings/
+#                   errors (issue #49), not just Python stdout. CAM
+#                   setup_stock CreateCylinder implemented; hole_wizard
+#                   infers hole_type from operation; fillet's non-Body path
+#                   now rejects out-of-range edges instead of silently
+#                   dropping them; subtractive_loft and list_joints/
+#                   get_part_status grounding visibility fixed. Broad
+#                   integration test coverage expansion (assembly, fixture,
+#                   continue_selection, and other previously-uncovered
+#                   tools); fixed a real pipe-full deadlock in the CI test
+#                   harness itself.
 
-__version__ = "7.2.0"
+__version__ = "7.3.0"
 
 # Minimum FreeCAD version required for CAM tools (the new Path Toolbit API).
 # Below this, cam_operations / cam_tools / cam_tool_controllers return a clean

--- a/AICopilot/freecad_mcp_handler.py
+++ b/AICopilot/freecad_mcp_handler.py
@@ -1387,7 +1387,7 @@ class FreeCADSocketServer:
             "chamfer_edges": self.partdesign_ops.chamfer_edges,
             "draft_faces": self.partdesign_ops.draft_faces,
             "shell_solid": self.partdesign_ops.shell_solid,
-            "thickness_faces": self.partdesign_ops.thickness_faces,
+            "thickness_faces": self.partdesign_ops.add_thickness,
         }
         method = resume_methods.get(resume_tool)
         if method is None:
@@ -1829,6 +1829,7 @@ class FreeCADSocketServer:
                 '_call_on_gui_thread_reload',
                 '_reload_handlers',   # rebind self so future reloads use latest code
                 '_instantiate_handlers',
+                '_continue_selection',
             ]
             for method_name in _dispatch_methods:
                 new_fn = getattr(new_self.FreeCADSocketServer, method_name, None)

--- a/AICopilot/handlers/assembly_ops.py
+++ b/AICopilot/handlers/assembly_ops.py
@@ -44,12 +44,20 @@ _DISTANCE2_JOINT_TYPES = frozenset({"Gears", "Belt"})
 _ANGLE_JOINT_TYPES = frozenset({"Angle"})
 
 # assembly.solve()'s return code, per AssemblyObject.pyi's documented
-# contract. Confirmed by source reading (2026-07-24) that only 0/-1/-6 are
-# actually reachable in the current FreeCAD tree -- -2/-3/-4/-5 are declared
-# in the docstring but the C++ implementation never returns them today. Kept
-# here in full for forward-compatibility and because the docstring is the
-# closed vocabulary FreeCAD itself commits to, not because all branches are
-# currently live.
+# contract. The 2026-07-24 source-reading note below claiming 0/-1/-6 are
+# "actually reachable" was itself wrong for -6 -- corrected 2026-08-21
+# after reading AssemblyObject.cpp directly: solve() returns -6 only when
+# fixGroundedParts()/getGroundedParts() finds an empty set, but
+# getGroundedParts() unconditionally inserts the assembly's own Origin
+# object into that set on every call (AssemblyObject.cpp, getGroundedParts(),
+# `groundedSet.insert(Origin.getValue())`) -- every assembly has an Origin
+# by construction, so the set can never actually be empty in normal use.
+# -6 is therefore effectively unreachable via this handler's solve(), same
+# as -2/-3/-4/-5 -- confirmed live: solve() with zero explicitly-grounded
+# parts returns code=0 (success), not -6, regardless of whether any joints
+# exist. Kept in _SOLVE_STATUS in full anyway, for the same reason -2..-5
+# already were: it's the closed vocabulary FreeCAD's own docstring commits
+# to, not a claim every branch is currently live.
 _SOLVE_STATUS = {
     0: "success",
     -1: "solver_error",
@@ -386,6 +394,27 @@ class AssemblyOpsHandler(BaseHandler):
         except Exception as e:
             return f"Error listing components: {e}"
 
+    def _find_joint_group(self, assembly):
+        """Return the assembly's Assembly::JointGroup child object, or
+        None if it doesn't have one yet.
+
+        assembly.Joints only ever contains real Joint objects, never
+        GroundedJoint ones -- confirmed live, contradicting both
+        list_joints' own docstring and get_part_status's "related joints"
+        display (which explicitly checks for ObjectToGround but iterated
+        assembly.Joints, so that branch was dead code in practice). The
+        JointGroup child (the "Joints" group UtilsAssembly.getJointGroup
+        manages) has both under its own .Group. Deliberately does NOT call
+        UtilsAssembly.getJointGroup(assembly) itself -- that function
+        auto-creates the group as a side effect if missing (confirmed
+        live), an unwanted mutation from what should be a read-only
+        lookup; this mirrors just its lookup half.
+        """
+        for obj in getattr(assembly, 'OutList', []) or []:
+            if obj.TypeId == "Assembly::JointGroup":
+                return obj
+        return None
+
     def _resolve_assembly(self, assembly_name: str, doc):
         """Shared assembly-resolution: explicit name, or first in document.
 
@@ -694,10 +723,16 @@ class AssemblyOpsHandler(BaseHandler):
         """Solve the assembly, updating part placements from its joints.
 
         The return code is mapped to a named status rather than left as a
-        bare int -- 0=success, -1=solver_error, -6=no_grounded_parts are the
-        codes actually reachable in the current FreeCAD tree; -2/-3/-4/-5
+        bare int. Only 0=success and -1=solver_error are actually reachable
+        in the current FreeCAD tree; -6=no_grounded_parts and -2/-3/-4/-5
         (redundant/conflicting/over_constrained/malformed) are declared in
-        FreeCAD's own contract but not currently produced by the solver.
+        FreeCAD's own contract but not currently produced by the solver --
+        -6 specifically because AssemblyObject.cpp's getGroundedParts()
+        unconditionally counts the assembly's own Origin object as
+        "grounded", so the empty-set check that would return -6 can never
+        actually trigger (confirmed by reading AssemblyObject.cpp directly,
+        2026-08-21; solve() with zero explicitly-grounded parts returns
+        code=0, not -6).
 
         Args:
             assembly_name: Assembly to solve (default: first
@@ -749,7 +784,8 @@ class AssemblyOpsHandler(BaseHandler):
             if err:
                 return err
 
-            joints = list(getattr(assembly, 'Joints', []) or [])
+            joint_group = self._find_joint_group(assembly)
+            joints = list(getattr(joint_group, 'Group', []) or []) if joint_group else []
             total = len(joints)
             if not joints:
                 return f"Assembly '{assembly.Name}' has no joints."
@@ -906,7 +942,8 @@ class AssemblyOpsHandler(BaseHandler):
                 pass
 
             related = []
-            for j in (getattr(assembly, 'Joints', []) or []):
+            joint_group = self._find_joint_group(assembly)
+            for j in (getattr(joint_group, 'Group', []) or []) if joint_group else []:
                 try:
                     if hasattr(j, 'ObjectToGround'):
                         if getattr(j.ObjectToGround, 'Name', None) == obj.Name:

--- a/AICopilot/handlers/cam_ops.py
+++ b/AICopilot/handlers/cam_ops.py
@@ -906,6 +906,13 @@ class CAMOpsHandler(BaseHandler):
                 error = Exception(f"Job '{job_name}' not found")
                 return self.log_and_return("configure_job", args, error=error, duration=time.time() - start_time)
 
+            if 'stock_type' in args:
+                # Stock type changes require setup_stock operation. Checked before any
+                # other field is applied so this doesn't silently half-apply a call that
+                # combines stock_type with output_file/post_processor/post_processor_args.
+                result = f"To change stock type, use the setup_stock operation instead"
+                return self.log_and_return("configure_job", args, result=result, duration=time.time() - start_time)
+
             updates = []
 
             if 'output_file' in args:
@@ -919,11 +926,6 @@ class CAMOpsHandler(BaseHandler):
             if 'post_processor_args' in args:
                 job.PostProcessorArgs = args['post_processor_args']
                 updates.append(f"post_processor_args: {args['post_processor_args']}")
-
-            if 'stock_type' in args:
-                # Stock type changes require setup_stock operation
-                result = f"To change stock type, use the setup_stock operation instead"
-                return self.log_and_return("configure_job", args, result=result, duration=time.time() - start_time)
 
             if not updates:
                 error = Exception("No parameters to update. Provide output_file, post_processor, or post_processor_args.")

--- a/AICopilot/handlers/cam_ops.py
+++ b/AICopilot/handlers/cam_ops.py
@@ -111,7 +111,7 @@ class CAMOpsHandler(BaseHandler):
         start_time = time.time()
         try:
             # FreeCAD 1.0+ uses new module structure
-            from Path.Main.Stock import CreateBox, CreateFromBase
+            from Path.Main.Stock import CreateBox, CreateCylinder, CreateFromBase
 
             doc = self.get_document()
             if not doc:
@@ -135,6 +135,10 @@ class CAMOpsHandler(BaseHandler):
                 job.Stock.Length = length
                 job.Stock.Width = width
                 job.Stock.Height = height
+            elif stock_type == 'CreateCylinder':
+                job.Stock = CreateCylinder(job)
+                job.Stock.Radius = args.get('radius', 50)
+                job.Stock.Height = height
             elif stock_type == 'FromBase':
                 job.Stock = CreateFromBase(job)
                 extent_x = args.get('extent_x', 10)
@@ -146,6 +150,20 @@ class CAMOpsHandler(BaseHandler):
                 job.Stock.ExtYpos = extent_y
                 job.Stock.ExtZneg = 0
                 job.Stock.ExtZpos = extent_z
+            else:
+                # Previously fell through silently here: none of the
+                # branches matched, job.Stock was left untouched (still
+                # whatever create_job auto-seeded), and this still
+                # returned a success message naming the unrecognized
+                # stock_type with no indication nothing happened
+                # (confirmed live, 2026-08-21 — pinned in
+                # tests/integration/test_cam_workflows.py::TestSetupStock
+                # before this fix). Reject explicitly instead.
+                error = Exception(
+                    f"Unknown stock_type: {stock_type!r}. Must be one of: "
+                    f"CreateBox, CreateCylinder, FromBase"
+                )
+                return self.log_and_return("setup_stock", args, error=error, duration=time.time() - start_time)
 
             job.recompute()
             result = f"Setup stock for job '{job_name}' using {stock_type}"

--- a/AICopilot/handlers/execute_python_ops.py
+++ b/AICopilot/handlers/execute_python_ops.py
@@ -5,7 +5,9 @@
 import ast
 import io
 import json
+import os
 import sys
+import threading
 import traceback as tb_module
 from typing import Any, Dict
 
@@ -29,6 +31,84 @@ class ExecutePythonOpsHandler(BaseHandler):
         # Persistent namespace for execute_python calls.
         # Variables created in one call survive to the next.
         self._python_namespace: Dict[str, Any] = {}
+
+    def _capture_console_stderr_start(self):
+        """Redirect the real OS-level stderr fd to a pipe with a background
+        drain thread, so FreeCAD's own C++ Console output (PrintWarning,
+        PrintError, PrintLog, PrintCritical -- and warnings FreeCAD emits
+        internally as a side effect of property sets/recomputes, e.g.
+        deprecation notices) gets captured instead of vanishing silently.
+
+        Confirmed via FreeCAD's own source (FC-clone/src/Base/
+        ConsoleObserver.cpp): ConsoleObserverStd::Warning/Error/Log/Critical
+        write via raw fprintf(stderr, ...) at the C level, below Python's
+        sys.stdout/sys.stderr -- redirecting those (as run_code already does
+        for stdout) never sees it. ConsoleObserverStd is unconditionally
+        attached with LoggingConsole="1" in both MainCmd.cpp (headless) and
+        MainGui.cpp (GUI), confirmed in the same source tree, so this works
+        in both modes. (Console.Message()/plain Msg-level output goes to
+        stdout instead, along with FreeCAD's recompute() progress-bar spam
+        -- deliberately NOT captured here, to avoid returning tick-spam
+        noise in the response; only stderr, i.e. actually-actionable
+        Warning/Error/Log/Critical output, is worth surfacing.)
+
+        A background drain thread (not a one-shot read at the end) avoids
+        the exact pipe-full deadlock class fixed in tests/integration/
+        conftest.py's _PipeDrain for the same underlying reason (an
+        unbounded fprintf into an unread OS pipe blocks forever once the
+        64KB buffer fills) -- unlikely here since stderr should be low-
+        volume, but the mechanism is identical so the same guard applies.
+
+        Returns a state dict for _capture_console_stderr_stop, or None if
+        redirection failed for any reason -- must never block or break
+        code execution just because this diagnostic capture couldn't be
+        set up.
+        """
+        try:
+            read_fd, write_fd = os.pipe()
+            saved_fd = os.dup(2)
+            os.dup2(write_fd, 2)
+            os.close(write_fd)
+        except OSError:
+            return None
+        buf = bytearray()
+        lock = threading.Lock()
+
+        def _drain():
+            try:
+                while True:
+                    chunk = os.read(read_fd, 4096)
+                    if not chunk:
+                        break
+                    with lock:
+                        buf.extend(chunk)
+            except OSError:
+                pass
+
+        thread = threading.Thread(target=_drain, daemon=True)
+        thread.start()
+        return {"read_fd": read_fd, "saved_fd": saved_fd, "buf": buf, "lock": lock, "thread": thread}
+
+    def _capture_console_stderr_stop(self, state) -> str:
+        """Restore the real stderr fd and return whatever was captured."""
+        if state is None:
+            return ""
+        try:
+            # Closes the pipe's write end (fd 2 was its only remaining
+            # reference -- the original write_fd number was already closed
+            # in _capture_console_stderr_start), which lets the drain
+            # thread's os.read() see EOF and exit.
+            os.dup2(state["saved_fd"], 2)
+            os.close(state["saved_fd"])
+        except OSError:
+            pass
+        state["thread"].join(timeout=1.0)
+        try:
+            os.close(state["read_fd"])
+        except OSError:
+            pass
+        with state["lock"]:
+            return bytes(state["buf"]).decode("utf-8", errors="replace").strip()
 
     def run_code(self, code: str) -> dict:
         """Core Python execution: runs code on the GUI thread, captures stdout.
@@ -72,6 +152,7 @@ class ExecutePythonOpsHandler(BaseHandler):
         result_value = None
         old_stdout = sys.stdout
         sys.stdout = captured = io.StringIO()
+        console_stderr_state = self._capture_console_stderr_start()
         try:
             try:
                 tree = ast.parse(code)
@@ -95,11 +176,14 @@ class ExecutePythonOpsHandler(BaseHandler):
             return {"error": f"Python execution error: {e}", "error_id": self.server.diagnostics_ops.store_traceback(tb_module.format_exc())}
         finally:
             sys.stdout = old_stdout
+            console_stderr = self._capture_console_stderr_stop(console_stderr_state)
 
         stdout_output = captured.getvalue().rstrip("\n")
         parts = []
         if stdout_output:
             parts.append(stdout_output)
+        if console_stderr:
+            parts.append(f"[FreeCAD Console]\n{console_stderr}")
         if result_value is not None:
             parts.append(repr(result_value))
 

--- a/AICopilot/handlers/fixture_ops.py
+++ b/AICopilot/handlers/fixture_ops.py
@@ -121,7 +121,15 @@ def _extract_topology(shape) -> Dict[str, Any]:
             "z": [bb.ZMin, bb.ZMax],
         },
         "center_of_mass": {"x": com.x, "y": com.y, "z": com.z},
-        "is_solid": bool(shape.isSolid()),
+        # shape.isSolid() was removed from FreeCAD's Part.Shape/Part.Solid
+        # Python API somewhere before weekly-2026.08.20 (confirmed live:
+        # AttributeError on every shape type, including a freshly-created
+        # Part::Box's own .Shape — not a one-off, isValid()/isClosed() on
+        # the same object still work fine). bool(shape.Solids) is a
+        # faithful replacement: a real solid's own .Solids traversal
+        # includes itself (len 1+), while a bare Face/open Shell's is
+        # empty — confirmed live against both cases.
+        "is_solid": bool(shape.Solids),
         "is_closed": bool(shape.isClosed()),
     }
 
@@ -135,9 +143,15 @@ def _write_binary_stl(shape, path: str) -> None:
     Raises on failure so the caller can surface the error to the MCP client.
     """
     import Mesh
-    mesh = Mesh.Mesh()
-    verts, tris = shape.tessellate(0.1)
-    mesh.addMesh(verts, tris)
+    # Mesh.Mesh.addMesh(verts, tris) was removed from FreeCAD's Python API
+    # somewhere before weekly-2026.08.20 (confirmed live: TypeError,
+    # "function takes exactly 1 argument (2 given)" — addMesh is now for
+    # combining two existing Mesh objects, not constructing from raw
+    # points/facets). The Mesh.Mesh(points_and_facets) tuple constructor
+    # still accepts tessellate()'s return value directly and is the
+    # documented modern replacement — confirmed live producing the correct
+    # facet count (12 for a 6-face box).
+    mesh = Mesh.Mesh(shape.tessellate(0.1))
     mesh.write(path)
 
 
@@ -147,7 +161,6 @@ def _write_stl_via_export(shape, path: str) -> None:
     MeshPart.meshFromShape produces better tessellations than the bare
     Mesh.Mesh approach for complex OCCT geometry (dormers, lofts, etc.).
     """
-    import Mesh
     import MeshPart
     mesh = MeshPart.meshFromShape(
         Shape=shape,
@@ -155,7 +168,13 @@ def _write_stl_via_export(shape, path: str) -> None:
         AngularDeflection=0.5,
         Relative=False,
     )
-    Mesh.export([mesh], path)
+    # Mesh.export([mesh], path) was the old call here -- confirmed live it
+    # now raises "TypeError: None of the objects can be exported to a mesh
+    # file": Mesh.export() expects real document objects, not the bare
+    # Mesh.MeshObject meshFromShape returns. That object has its own
+    # write() method, confirmed live to produce a valid non-empty STL file
+    # directly -- no export() wrapper needed.
+    mesh.write(path)
 
 
 def _export_stl(shape, path: str) -> None:

--- a/AICopilot/handlers/partdesign_ops.py
+++ b/AICopilot/handlers/partdesign_ops.py
@@ -455,7 +455,20 @@ class PartDesignOpsHandler(BaseHandler):
         """
         try:
             object_name = args.get('object_name', '')
-            hole_type = args.get('hole_type', 'simple')
+            # hole/counterbore/countersink all dispatch here as the same
+            # method (freecad_mcp_handler.py's operation_map) -- hole_type
+            # used to default to 'simple' whenever the caller didn't pass
+            # it explicitly, silently ignoring which of the three
+            # operations was actually called (confirmed live 2026-08-21:
+            # operation="counterbore" with no hole_type created a plain
+            # hole). args['operation'] is the original dispatched
+            # operation name, still present in this same args dict --
+            # infer hole_type from it when not given explicitly, so the
+            # operation name itself is authoritative instead of a
+            # same-value-for-all-three default.
+            hole_type = args.get('hole_type') or {
+                'counterbore': 'counterbore', 'countersink': 'countersink',
+            }.get(args.get('operation', ''), 'simple')
             diameter = args.get('diameter', 6)
             depth = args.get('depth', 10)
             x = args.get('x', 0)

--- a/AICopilot/handlers/partdesign_ops.py
+++ b/AICopilot/handlers/partdesign_ops.py
@@ -1236,7 +1236,20 @@ class PartDesignOpsHandler(BaseHandler):
                 return "Sketches must be in a PartDesign Body"
 
             loft = body.newObject("PartDesign::SubtractiveLoft", name)
-            loft.Sections = sketch_objs
+            # PartDesign::SubtractiveLoft (like every other PartDesign
+            # additive/subtractive feature) has its own required Profile
+            # property distinct from Sections -- unlike the standalone
+            # Part::Loft this method used to be modeled after, which only
+            # has Sections. Leaving Profile unset (the bug: this used to
+            # just do `loft.Sections = sketch_objs` with every sketch,
+            # including the first) leaves the feature permanently
+            # State=Invalid with a null Shape -- confirmed live, reproduced
+            # identically even on the additive sibling PartDesign::AdditiveLoft
+            # with no subtraction involved at all, so it was never a
+            # subtraction-specific issue. Profile takes the first sketch;
+            # Sections takes the rest.
+            loft.Profile = sketch_objs[0]
+            loft.Sections = sketch_objs[1:]
 
             self.recompute(doc)
 

--- a/AICopilot/handlers/partdesign_ops.py
+++ b/AICopilot/handlers/partdesign_ops.py
@@ -252,13 +252,26 @@ class PartDesignOpsHandler(BaseHandler):
                 edge_names = [f"Edge{idx}" for idx in edges]
                 fillet.Base = (obj, edge_names)
             else:
+                # Validate BEFORE creating anything -- an out-of-range index
+                # used to be silently dropped here (edge_list built via
+                # `if 1 <= idx <= n_edges`), creating a fillet on fewer
+                # edges than requested with no indication any were
+                # skipped. The Body path above has no such filter at all
+                # (an invalid index there reaches OCCT directly and fails
+                # loudly via _check_feature_state below) -- reject
+                # up front here instead of silently under-filleting,
+                # matching that same "fail loud, not quiet" contract
+                # (fixed 2026-08-21).
+                n_edges = len(obj.Shape.Edges) if hasattr(obj, 'Shape') else 0
+                invalid = [idx for idx in edges if not (1 <= idx <= n_edges)]
+                if invalid:
+                    return (
+                        f"Invalid edge index/indices {invalid} for {object_name} "
+                        f"({n_edges} edges, valid range 1-{n_edges})"
+                    )
                 fillet = doc.addObject("Part::Fillet", name)
                 fillet.Base = obj
-                # Bounds-check like _create_fillet_with_selection — an out-of-range
-                # index otherwise produces a cryptic OCCT recompute error.
-                n_edges = len(obj.Shape.Edges) if hasattr(obj, 'Shape') else 0
-                edge_list = [(idx, radius, radius) for idx in edges if 1 <= idx <= n_edges]
-                fillet.Edges = edge_list
+                fillet.Edges = [(idx, radius, radius) for idx in edges]
 
             self.recompute(doc)
 

--- a/AICopilot/handlers/view_ops.py
+++ b/AICopilot/handlers/view_ops.py
@@ -446,7 +446,19 @@ class ViewOpsHandler(BaseHandler):
             return f"Error in recompute: {e}"
 
     def undo(self, args: Dict[str, Any]) -> str:
-        """Undo the last operation."""
+        """Undo the last operation.
+
+        KNOWN LIMITATION: this is effectively a no-op for MCP-driven changes.
+        doc.undo()/doc.redo() only replay FreeCAD *transactions*, and nothing
+        in the dispatch path (_call_on_gui_thread_async / _dispatch_to_handler
+        in freecad_mcp_handler.py) ever opens one around a handler call — that
+        only happens automatically for real GUI-driven edits. So this reports
+        "Undo completed" whether or not anything was actually undone. See
+        CLAUDE.md's Known Issues for why this isn't a small fix (transaction
+        boundaries would need to be added at the dispatch chokepoint(s), with
+        a read/write classification per operation to avoid polluting the
+        undo stack with empty transactions for read-only calls).
+        """
         try:
             doc = FreeCAD.ActiveDocument
             if not doc:
@@ -457,7 +469,7 @@ class ViewOpsHandler(BaseHandler):
             return f"Error during undo: {e}"
 
     def redo(self, args: Dict[str, Any]) -> str:
-        """Redo the last undone operation."""
+        """Redo the last undone operation. See undo()'s docstring — same limitation."""
         try:
             doc = FreeCAD.ActiveDocument
             if not doc:

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -723,8 +723,8 @@ confirming it no longer happens.
 
 ### Issue: `execute_python()` never surfaces FreeCAD Console warnings/errors, only Python stdout
 
-**Status**: NOT FIXED (open) — design decision deferred, not just an
-implementation gap
+**Status**: FIXED (2026-08-21) — see below; scope kept to `execute_python()`
+only, per the open design question this issue originally raised
 **Severity**: Low-medium — no crash, but real FreeCAD-level warnings
 (deprecation notices, recompute warnings, etc.) triggered by code run through
 `execute_python()` are silently invisible to the caller unless they separately
@@ -760,19 +760,65 @@ output functions plus `SetStatus`/`GetStatus`/`GetObservers` for observers
 that are already registered by name (e.g. the GUI Report View widget
 registers itself natively in C++) — no `SetObserver`/callback-registration
 entry point for arbitrary Python objects turned up in this version's source.
+Re-confirmed still true 2026-08-21 against a current build.
 
-#### Suggested fix (not yet decided on)
+#### Suggested fix in the original report — investigated further, NOT what shipped
 
-Doesn't need that observer API — `get_report_view` already works (used
-successfully by hand during the coach-side session). `run_code()` could
-snapshot the Report View tail before executing user code, run it, then diff
-and fold any new Warning/Error-level lines into the response automatically.
-Same underlying mechanism as the manual workaround, just applied proactively.
+The original suggestion was: snapshot the Report View tail before executing
+user code, run it, then diff and fold any new Warning/Error-level lines into
+the response. Re-examined this before implementing anything: `get_report_view`
+(`AICopilot/handlers/view_ops.py`) reads a literal Qt `QTextEdit` widget via
+`FreeCADGui.getMainWindow()` — **GUI-only**. It would silently do nothing for
+any headless-spawned instance (`spawn_freecad_instance`, the entire
+integration-test tier), which is a real, common way this server runs. Diffing
+Report View text was never going to work universally.
 
-**Open design question, deliberately left unresolved:** should this live only
-in `execute_python()`, or should every mutating tool call pay the same
-before/after Report View diff? `execute_python()` is the highest-value target
-(arbitrary code, hardest to predict what it'll trigger), but the same class
-of silent-warning problem could in principle happen from any handler that
-calls into FreeCAD's property/recompute machinery. Deferred rather than
-guessed at — needs a real decision, not a quick patch.
+#### What actually shipped: OS-level stderr fd capture, not a Report View diff
+
+Verified in FreeCAD's own source (`FC-clone/src/Base/ConsoleObserver.cpp`):
+`ConsoleObserverStd::Warning()`/`Error()`/`Log()`/`Critical()` write via raw
+`fprintf(stderr, ...)` at the C level — below Python's `sys.stdout`/
+`sys.stderr`, which is exactly why the existing `io.StringIO()` capture never
+saw it. `ConsoleObserverStd` is unconditionally attached with
+`LoggingConsole="1"` in both `MainCmd.cpp` (headless) and `MainGui.cpp` (GUI)
+— confirmed in the same source tree — so this works in both modes, unlike the
+Report-View-diff idea.
+
+`run_code()` now redirects the real OS-level stderr fd (`os.dup2`) to a pipe
+for the duration of code execution, with a background drain thread (not a
+one-shot read at the end — the exact mechanism that caused a real pipe-full
+deadlock in this repo's own CI test harness the same day; see
+`tests/integration/conftest.py`'s `_PipeDrain`) so it can never block FreeCAD
+on `write()` if a lot of Console output happens. Captured stderr is folded
+into the response text under a `[FreeCAD Console]` heading. `stdout`-level
+Console output (`Console.Message()`, plus FreeCAD's `recompute()`
+progress-bar spam) is deliberately NOT captured this way — it's noise, not
+what this issue was about.
+
+**Real regression found and fixed during this work**: folding Console
+stderr into the same opaque `"result"` string can break a caller relying on
+`execute_python`'s output being *exactly* machine-parseable (e.g.
+`tests/integration/test_api_surface.py`'s live-scan, which does
+`print(json.dumps(...))` as the last statement and expects the whole response
+to be valid JSON) if FreeCAD emits any incidental Console output during that
+call — confirmed live: a routine `Log`-level message from
+`PartDesign::Hole`'s thread-definition lookup, not even a real warning, broke
+`json.loads()` on the response. The dispatch envelope
+(`freecad_mcp_handler.py::_run_on_gui_thread`) only ever forwards a
+handler's `"result"`/`"error"` dict keys — there's no separate structured
+channel to put Console output in without touching that shared chokepoint,
+which is exactly the kind of "every mutating tool call" scope-widening this
+issue's own open question was about avoiding without a deliberate decision.
+Fixed the one real internal consumer instead:
+`tests/integration/_api_surface_remote.py::parse_remote_scan_result()` now
+parses only the first line of the response (the JSON is always the remote
+driver's last `print()`), shared by both `test_api_surface.py` and
+`generate_api_surface_snapshot.py` rather than duplicated. Any other consumer
+that needs execute_python's stdout to be byte-exact should be aware Console
+output can now be appended after it.
+
+**Open design question from the original report, still deliberately
+unresolved:** should every mutating tool call get the same treatment, not
+just `execute_python()`? Not decided here — scope was kept to
+`execute_python()` only, the highest-value target (arbitrary code, hardest to
+predict what it'll trigger) and the one this issue was actually filed about.

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -1254,7 +1254,7 @@ async def main():
                     "job_name": {"type": "string", "description": "CAM job name"},
                     "base_object": {"type": "string", "description": "Base 3D object for CAM operations"},
                     # Stock parameters
-                    "stock_type": {"type": "string", "description": "Stock type", "enum": ["CreateBox", "CreateCylinder", "FromBase"], "default": "CreateBox"},
+                    "stock_type": {"type": "string", "description": "Stock type (default CreateBox)", "enum": ["CreateBox", "CreateCylinder", "FromBase"]},
                     "length": {"type": "number", "description": "Stock length", "default": 100},
                     "width": {"type": "number", "description": "Stock width", "default": 100},
                     "height": {"type": "number", "description": "Stock height", "default": 50},
@@ -1286,7 +1286,7 @@ async def main():
                     "feed_rate": {"type": "number", "description": "Feed rate in mm/min", "default": 1000},
                     # Post-processing parameters
                     "output_file": {"type": "string", "description": "Output G-code file path"},
-                    "post_processor": {"type": "string", "description": "Post processor name", "default": "grbl"},
+                    "post_processor": {"type": "string", "description": "Post processor name (default grbl)"},
                     "post_processor_args": {"type": "string", "description": "Post processor arguments (e.g. '--no-show-editor')"},
                     # Adaptive parameters
                     "tolerance": {"type": "number", "description": "Adaptive tolerance"},
@@ -1318,7 +1318,7 @@ async def main():
                         "enum": ["endmill", "ballend", "bullnose", "chamfer", "drill", "v-bit"],
                         "default": "endmill"
                     },
-                    "diameter": {"type": "number", "description": "Tool diameter in mm", "default": 6.0},
+                    "diameter": {"type": "number", "description": "Tool diameter in mm (default 6.0)"},
                     "flute_length": {"type": "number", "description": "Cutting edge length in mm"},
                     "shank_diameter": {"type": "number", "description": "Shank diameter in mm"},
                     "material": {"type": "string", "description": "Tool material (HSS, Carbide, etc.)"},
@@ -1346,10 +1346,10 @@ async def main():
                     "job_name": {"type": "string", "description": "CAM job name"},
                     "tool_name": {"type": "string", "description": "Name of the tool bit to use"},
                     "controller_name": {"type": "string", "description": "Name for the tool controller"},
-                    "spindle_speed": {"type": "number", "description": "Spindle speed in RPM", "default": 10000},
-                    "feed_rate": {"type": "number", "description": "Horizontal feed rate in mm/min", "default": 1000},
+                    "spindle_speed": {"type": "number", "description": "Spindle speed in RPM (default 10000)"},
+                    "feed_rate": {"type": "number", "description": "Horizontal feed rate in mm/min (default 1000)"},
                     "vertical_feed_rate": {"type": "number", "description": "Vertical (plunge) feed rate in mm/min"},
-                    "tool_number": {"type": "integer", "description": "Tool number for G-code", "default": 1}
+                    "tool_number": {"type": "integer", "description": "Tool number for G-code. Omit to auto-assign the next available number"}
                 },
                 "required": ["operation"]
             },

--- a/freecad_mcp_server.py
+++ b/freecad_mcp_server.py
@@ -1255,9 +1255,10 @@ async def main():
                     "base_object": {"type": "string", "description": "Base 3D object for CAM operations"},
                     # Stock parameters
                     "stock_type": {"type": "string", "description": "Stock type (default CreateBox)", "enum": ["CreateBox", "CreateCylinder", "FromBase"]},
-                    "length": {"type": "number", "description": "Stock length", "default": 100},
-                    "width": {"type": "number", "description": "Stock width", "default": 100},
-                    "height": {"type": "number", "description": "Stock height", "default": 50},
+                    "length": {"type": "number", "description": "Stock length (CreateBox)", "default": 100},
+                    "width": {"type": "number", "description": "Stock width (CreateBox)", "default": 100},
+                    "height": {"type": "number", "description": "Stock height (CreateBox/CreateCylinder)", "default": 50},
+                    "radius": {"type": "number", "description": "Stock radius, mm (CreateCylinder; default 50)"},
                     "extent_x": {"type": "number", "description": "Stock extent in X", "default": 10},
                     "extent_y": {"type": "number", "description": "Stock extent in Y", "default": 10},
                     "extent_z": {"type": "number", "description": "Stock extent in Z", "default": 10},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ testpaths = ["tests/unit"]
 markers = [
     "cam: requires FreeCAD 1.2-dev (CAM/Path workbench)",
     "real_document: exercises a real, complex .FCStd fixture -- slower/heavier than the rest of the suite; run on PR, not every push",
+    "fc_tools: requires the FC-tools sibling repo on sys.path (Inspector, SketchBuilder) -- present on the dev machine, not checked out in CI",
 ]
 
 # Coverage is a floor-check, not a quality gate — deliberately not wired

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "freecad-mcp"
-version = "7.2.0"
+version = "7.3.0"
 description = "MCP server to control FreeCAD from Claude"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.blwfish/freecad-mcp",
   "title": "FreeCAD MCP",
   "description": "Control FreeCAD from Claude — 3D modeling, PartDesign, CAM toolpaths, and more via 30+ tools.",
-  "version": "7.2.0",
+  "version": "7.3.0",
   "repository": {
     "url": "https://github.com/blwfish/freecad-mcp",
     "source": "github"

--- a/tests/integration/_api_surface_remote.py
+++ b/tests/integration/_api_surface_remote.py
@@ -5,7 +5,13 @@ in the test-runner process) and prepended to ``execute_python`` code blocks
 by both the golden-snapshot generator and the drift test itself, so the
 translation/description logic lives in exactly one place rather than being
 duplicated as separate strings in two places.
+
+build_remote_scan_code() and parse_remote_scan_result() below are the
+exception -- they run locally in the test-runner process (building the
+remote code string, and parsing what comes back), not inside FreeCAD.
 """
+
+import json
 
 
 def _resolve_type_to_instance(doc, type_id):
@@ -110,8 +116,6 @@ def build_remote_scan_code(scope):
     driver code that both scripts need in exactly one place rather than
     duplicated as two near-identical f-strings.
     """
-    import json
-
     with open(__file__) as f:
         helpers_src = f.read()
     scope_literal = json.dumps({k: sorted(v) for k, v in scope.items()})
@@ -140,3 +144,26 @@ except Exception as e:
     snapshot["__meta__"] = {{"freecad_version": f"__ERROR__: {{e}}"}}
 print(_json.dumps(snapshot))
 """
+
+
+def parse_remote_scan_result(result_str: str) -> dict:
+    """Parse execute_python_sync's response text into the scan's JSON dict.
+
+    build_remote_scan_code's remote driver ends with a single
+    ``print(_json.dumps(snapshot))`` as its last statement, so the JSON is
+    always the first line of stdout -- but execute_python_ops.py's
+    run_code() may append a "[FreeCAD Console]\\n..." section afterward
+    when FreeCAD's C++ layer emits any Console output during the scan
+    (confirmed live: routine Log-level chatter from PartDesign::Hole's
+    thread-definition lookup, not even a real warning, but the capture
+    doesn't discriminate by severity -- see issue #49's fix in
+    AICopilot/handlers/execute_python_ops.py). Parse only the first line
+    rather than the whole string, so incidental Console noise appended
+    after the JSON doesn't fail the scan.
+
+    Raises json.JSONDecodeError (same as a bare json.loads would) if even
+    the first line isn't valid JSON -- both call sites already handle
+    that themselves.
+    """
+    first_line = result_str.split("\n", 1)[0]
+    return json.loads(first_line)

--- a/tests/integration/api_surface_snapshot.json
+++ b/tests/integration/api_surface_snapshot.json
@@ -229,6 +229,7 @@
     "ReferenceAxis": "App::PropertyLinkSub"
   },
   "PartDesign::SubtractiveLoft": {
+    "Profile": "App::PropertyLinkSub",
     "Sections": "App::PropertyLinkSubList"
   },
   "PartDesign::SubtractivePipe": {
@@ -251,12 +252,12 @@
       "26",
       "3",
       "0",
-      "47780 +9 (Git)",
+      "48135 +15 (Git)",
       "Unknown",
-      "2026/07/22 10:27:21",
+      "2026/08/21 00:39:22",
       "blw-fixes-v7",
-      "e66fa73e6fe62a60f7bdbe495d42eb906da2493c"
+      "d4f5f7bc5f8f58029b0f681224562efecf5e7fe9"
     ],
-    "generated_at": "2026-07-28T19:42:48.338890+00:00"
+    "generated_at": "2026-08-21T06:46:58.632601+00:00"
   }
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -326,9 +326,44 @@ def _extract_relevant(text: str, max_chars: int = 30000) -> str:
     return text[-max_chars:]
 
 
-def _gdb_attach_dump(pid: int, run_timeout: int = 25) -> str:
-    """Attach gdb to a live (presumably hung) process and dump every
-    thread's backtrace, then detach without killing it.
+def _find_descendant_pids(root_pid: int) -> list[int]:
+    """Return every live descendant of root_pid, via /proc/<pid>/task/<pid>/children.
+
+    The Popen'd process is the AppImage wrapper script (freecadcmd-wrapper.sh
+    -> AppRun), NOT the real FreeCAD binary -- confirmed live (2026-08-21):
+    a first version of this tool that only attached to root_pid dumped a
+    thread named "AppRun" sitting in a completely ordinary bash wait4()
+    for its child (wait_for/execute_command/reader_loop -- bash's own
+    interpreter loop, ../sysdeps wait4.c), telling us nothing about the
+    real hang. AppRun forks and waits rather than exec'ing into the real
+    binary (if it exec'd, it would keep the same pid and this walk would
+    be unnecessary) -- so the process actually holding whatever lock is
+    deadlocked lives one or more fork() hops below root_pid. Returns [] on
+    any /proc access failure (e.g. not Linux) rather than raising --
+    caller falls back to dumping root_pid alone in that case.
+    """
+    descendants: list[int] = []
+    frontier = [root_pid]
+    seen = {root_pid}
+    while frontier:
+        pid = frontier.pop()
+        try:
+            with open(f"/proc/{pid}/task/{pid}/children") as f:
+                children = [int(p) for p in f.read().split()]
+        except (OSError, ValueError):
+            continue
+        for child in children:
+            if child not in seen:
+                seen.add(child)
+                descendants.append(child)
+                frontier.append(child)
+    return descendants
+
+
+def _gdb_attach_dump(root_pid: int, run_timeout: int = 25) -> str:
+    """Attach gdb to a live (presumably hung) process tree and dump every
+    thread's backtrace from every descendant, then detach without killing
+    any of them.
 
     This is deliberately reactive -- attach only once a real timeout has
     already happened -- not the whole-session gdb-wrap the CAM SIGSEGV
@@ -342,6 +377,11 @@ def _gdb_attach_dump(pid: int, run_timeout: int = 25) -> str:
     lesson that dumping locals across many/deep-stacked threads can itself
     run long; if this needs revisiting, check that comment first.
 
+    root_pid itself is the AppImage wrapper, not the real binary (see
+    _find_descendant_pids) -- dump every live descendant too, since we
+    don't know in advance how many fork hops separate the wrapper from
+    the real FreeCAD process, or whether more than one of them matters.
+
     Best-effort and silent on any failure (gdb missing, ptrace denied,
     sudo not configured passwordless) -- this only ever runs after a test
     has already failed, so it must never raise or itself hang the run.
@@ -351,24 +391,28 @@ def _gdb_attach_dump(pid: int, run_timeout: int = 25) -> str:
     """
     if not shutil.which("gdb"):
         return "(gdb not available -- skipping live thread dump)"
-    cmd = [
-        "timeout", "-s", "KILL", str(run_timeout),
-        "sudo", "-n", "gdb", "-p", str(pid), "-batch",
-        "-ex", "echo \\n===GDB-ATTACHED===\\n",
-        "-ex", "thread apply all bt",
-        "-ex", "detach",
-        "-ex", "quit",
-    ]
-    try:
-        result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=run_timeout + 5,
-        )
-        return (
-            f"--- gdb live thread dump (pid={pid}, rc={result.returncode}) ---\n"
-            f"{result.stdout}\n{result.stderr}"
-        )
-    except Exception as e:
-        return f"(gdb attach to pid={pid} failed: {e})"
+    targets = [root_pid] + _find_descendant_pids(root_pid)
+    chunks = []
+    for pid in targets:
+        cmd = [
+            "timeout", "-s", "KILL", str(run_timeout),
+            "sudo", "-n", "gdb", "-p", str(pid), "-batch",
+            "-ex", "echo \\n===GDB-ATTACHED===\\n",
+            "-ex", "thread apply all bt",
+            "-ex", "detach",
+            "-ex", "quit",
+        ]
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=run_timeout + 5,
+            )
+            chunks.append(
+                f"--- gdb live thread dump (pid={pid}, rc={result.returncode}) ---\n"
+                f"{result.stdout}\n{result.stderr}"
+            )
+        except Exception as e:
+            chunks.append(f"(gdb attach to pid={pid} failed: {e})")
+    return "\n".join(chunks)
 
 
 def diagnose_dead_spawned_process() -> str:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -306,6 +306,7 @@ def get_socket_path() -> str:
 
 
 _death_diagnostics: str | None = None
+_hang_diagnostics: str | None = None
 
 # gdb's crash backtrace (KNOWN_ISSUES.md's create_tool SIGSEGV) starts at
 # one of these; a plain trailing slice missed it entirely in an earlier
@@ -325,25 +326,82 @@ def _extract_relevant(text: str, max_chars: int = 30000) -> str:
     return text[-max_chars:]
 
 
+def _gdb_attach_dump(pid: int, run_timeout: int = 25) -> str:
+    """Attach gdb to a live (presumably hung) process and dump every
+    thread's backtrace, then detach without killing it.
+
+    This is deliberately reactive -- attach only once a real timeout has
+    already happened -- not the whole-session gdb-wrap the CAM SIGSEGV
+    investigation used (FREECAD_MCP_TEST_GDB_TRAP): that approach is known
+    to introduce its own ~20s stall mid-run (see integration-tests.yml's
+    comment on why that flag is off for the routine suite). A hang has no
+    signal to catch anyway -- there's nothing for a whole-session wrapper
+    to intercept -- so a live `gdb -p <pid>` attach at the moment of
+    failure is the only way to see what every thread is actually blocked
+    on. "thread apply all bt" (no "full") mirrors the SIGSEGV trap's own
+    lesson that dumping locals across many/deep-stacked threads can itself
+    run long; if this needs revisiting, check that comment first.
+
+    Best-effort and silent on any failure (gdb missing, ptrace denied,
+    sudo not configured passwordless) -- this only ever runs after a test
+    has already failed, so it must never raise or itself hang the run.
+    Requires sudo: gdb is a fresh sibling process, not an ancestor of the
+    FreeCAD process, so default Yama ptrace_scope=1 (Ubuntu's default)
+    denies a plain attach.
+    """
+    if not shutil.which("gdb"):
+        return "(gdb not available -- skipping live thread dump)"
+    cmd = [
+        "timeout", "-s", "KILL", str(run_timeout),
+        "sudo", "-n", "gdb", "-p", str(pid), "-batch",
+        "-ex", "echo \\n===GDB-ATTACHED===\\n",
+        "-ex", "thread apply all bt",
+        "-ex", "detach",
+        "-ex", "quit",
+    ]
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=run_timeout + 5,
+        )
+        return (
+            f"--- gdb live thread dump (pid={pid}, rc={result.returncode}) ---\n"
+            f"{result.stdout}\n{result.stderr}"
+        )
+    except Exception as e:
+        return f"(gdb attach to pid={pid} failed: {e})"
+
+
 def diagnose_dead_spawned_process() -> str:
-    """If we spawned a headless instance and it has since died, return a
-    diagnostic string with its exit code and captured stdout/stderr.
+    """If we spawned a headless instance, return a diagnostic string:
+    exit code + captured stdout/stderr if it died, or a live gdb thread
+    dump if it's still running (hung rather than crashed).
 
     Nothing else ever drains _spawned_proc's stdout/stderr pipes while
     tests are running, so a mid-run crash (e.g. a native segfault in
     FreeCAD/OCCT) leaves whatever it printed sitting unread in the pipe
     buffer -- silently discarded once the test session ends. Call this
-    from a connection-failure handler to surface it instead.
+    from a connection-failure or timeout handler to surface it instead.
 
-    subprocess.communicate() closes the pipes on first use, so the result
-    is cached after the first successful read.
+    subprocess.communicate() closes the pipes on first use, and the gdb
+    attach suspends-then-detaches the target, so both branches' results
+    are cached after the first call -- every later cascading failure in
+    the same session reuses the cached diagnostic instead of re-attaching.
     """
-    global _death_diagnostics
+    global _death_diagnostics, _hang_diagnostics
     if _death_diagnostics is not None:
         return _death_diagnostics
+    if _hang_diagnostics is not None:
+        return _hang_diagnostics
     proc = _spawned_proc
-    if proc is None or proc.poll() is None:
+    if proc is None:
         return ""
+    if proc.poll() is None:
+        _hang_diagnostics = (
+            f"\nSpawned FreeCAD process (pid={proc.pid}) is still alive but "
+            f"unresponsive -- likely hung/deadlocked, not crashed.\n"
+            f"{_gdb_attach_dump(proc.pid)}"
+        )
+        return _hang_diagnostics
     try:
         stdout, stderr = proc.communicate(timeout=2)
         stdout = stdout.decode("utf-8", errors="replace") if stdout else ""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -15,6 +15,7 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
 import time
 import uuid
 
@@ -26,6 +27,61 @@ _DEFAULT_SOCKET = os.environ.get("FREECAD_MCP_SOCKET", "/tmp/freecad_mcp.sock")
 # Will be set by the session fixture — tests import this
 _active_socket_path: str | None = None
 _spawned_proc: subprocess.Popen | None = None
+_spawned_stdout_drain: "_PipeDrain | None" = None
+_spawned_stderr_drain: "_PipeDrain | None" = None
+
+
+class _PipeDrain:
+    """Continuously drain a subprocess pipe into a bounded in-memory
+    buffer, so a high-volume writer on the other end can never fill the
+    OS pipe buffer and block forever on write().
+
+    This is the actual, confirmed root cause of the 1.1-stable CI hangs
+    (see CLAUDE.md's Known Issues) -- live gdb thread dump (2026-08-21,
+    CI run 32462244329) caught a "freecadcmd" thread stuck in a raw
+    write(fd=1, ...) from Base::SequencerLauncher::next(), FreeCAD's own
+    console progress-bar output ("\\t\\t\\t(66 %)\\t\\r...") during
+    recompute(). _spawn_headless() pipes stdout/stderr
+    (stdout=subprocess.PIPE) but nothing ever read them while tests ran
+    -- only diagnose_dead_spawned_process() did, via proc.communicate(),
+    and only after the process had already died. Once cumulative
+    progress-tick output across ~250+ recomputes filled the 64KB pipe
+    buffer, that write() blocked forever: the process couldn't die (it
+    was stuck on the write, not exiting), so nothing would ever read and
+    unblock it either -- every later socket request piled up behind the
+    same permanently-stuck thread. A background reader that drains as
+    output arrives, same as subprocess.communicate() does internally via
+    select/poll, just running for the process's whole lifetime instead of
+    a one-shot call at the end.
+    """
+
+    def __init__(self, pipe, max_bytes: int = 200_000):
+        self._buf = bytearray()
+        self._max_bytes = max_bytes
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._run, args=(pipe,), daemon=True)
+        self._thread.start()
+
+    def _run(self, pipe) -> None:
+        try:
+            while True:
+                chunk = pipe.read(4096)
+                if not chunk:
+                    break
+                with self._lock:
+                    self._buf.extend(chunk)
+                    overflow = len(self._buf) - self._max_bytes
+                    if overflow > 0:
+                        del self._buf[:overflow]
+        except (OSError, ValueError):
+            pass
+
+    def text(self) -> str:
+        with self._lock:
+            return bytes(self._buf).decode("utf-8", errors="replace")
+
+    def join(self, timeout: float = 1.0) -> None:
+        self._thread.join(timeout=timeout)
 
 
 def _socket_responds(path: str, timeout: float = 2.0) -> bool:
@@ -202,19 +258,22 @@ def _spawn_headless(timeout: float = 30.0) -> tuple[subprocess.Popen, str]:
         stderr=subprocess.PIPE,
         start_new_session=True,
     )
+    # Drain immediately, not just on death -- see _PipeDrain's docstring
+    # for why an undrained pipe deadlocks the whole process eventually.
+    global _spawned_stdout_drain, _spawned_stderr_drain
+    _spawned_stdout_drain = _PipeDrain(proc.stdout)
+    _spawned_stderr_drain = _PipeDrain(proc.stderr)
 
     # Poll for readiness
     deadline = time.time() + timeout
     while time.time() < deadline:
         if proc.poll() is not None:
-            stdout = proc.stdout.read().decode("utf-8", errors="replace") if proc.stdout else ""
-            stderr = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
             raise RuntimeError(
                 f"FreeCADCmd exited prematurely with code {proc.returncode}\n"
                 f"  cmd: {cmd}\n"
                 f"  socket: {sock_path}\n"
-                f"  stdout: {stdout[:500]}\n"
-                f"  stderr: {stderr[:500]}"
+                f"  stdout: {_spawned_stdout_drain.text()[-500:]}\n"
+                f"  stderr: {_spawned_stderr_drain.text()[-500:]}"
             )
         if _socket_responds(sock_path):
             return proc, sock_path
@@ -420,16 +479,16 @@ def diagnose_dead_spawned_process() -> str:
     exit code + captured stdout/stderr if it died, or a live gdb thread
     dump if it's still running (hung rather than crashed).
 
-    Nothing else ever drains _spawned_proc's stdout/stderr pipes while
-    tests are running, so a mid-run crash (e.g. a native segfault in
-    FreeCAD/OCCT) leaves whatever it printed sitting unread in the pipe
-    buffer -- silently discarded once the test session ends. Call this
-    from a connection-failure or timeout handler to surface it instead.
+    _PipeDrain threads (started in _spawn_headless) continuously drain
+    _spawned_proc's stdout/stderr while tests run -- both because that's
+    what prevents the pipe-full deadlock (see _PipeDrain's docstring) and
+    as a side benefit, it means a mid-run crash's output is already
+    captured here rather than sitting unread in a pipe buffer. Call this
+    from a connection-failure or timeout handler to surface it.
 
-    subprocess.communicate() closes the pipes on first use, and the gdb
-    attach suspends-then-detaches the target, so both branches' results
-    are cached after the first call -- every later cascading failure in
-    the same session reuses the cached diagnostic instead of re-attaching.
+    Both branches' results are cached after the first call -- every later
+    cascading failure in the same session reuses the cached diagnostic
+    instead of re-attaching gdb or re-reading the drains.
     """
     global _death_diagnostics, _hang_diagnostics
     if _death_diagnostics is not None:
@@ -446,12 +505,12 @@ def diagnose_dead_spawned_process() -> str:
             f"{_gdb_attach_dump(proc.pid)}"
         )
         return _hang_diagnostics
-    try:
-        stdout, stderr = proc.communicate(timeout=2)
-        stdout = stdout.decode("utf-8", errors="replace") if stdout else ""
-        stderr = stderr.decode("utf-8", errors="replace") if stderr else ""
-    except Exception as e:
-        stdout, stderr = "", f"<failed to read pipes: {e}>"
+    if _spawned_stdout_drain is not None:
+        _spawned_stdout_drain.join(timeout=1.0)
+    if _spawned_stderr_drain is not None:
+        _spawned_stderr_drain.join(timeout=1.0)
+    stdout = _spawned_stdout_drain.text() if _spawned_stdout_drain else ""
+    stderr = _spawned_stderr_drain.text() if _spawned_stderr_drain else ""
     _death_diagnostics = (
         f"\nSpawned FreeCAD process died unexpectedly: returncode={proc.returncode}\n"
         f"--- stdout (from crash, if found, else tail) ---\n{_extract_relevant(stdout)}\n"

--- a/tests/integration/generate_api_surface_snapshot.py
+++ b/tests/integration/generate_api_surface_snapshot.py
@@ -29,7 +29,7 @@ if __package__ in (None, ""):
     __package__ = "tests.integration"
 
 from . import conftest
-from ._api_surface_remote import build_remote_scan_code
+from ._api_surface_remote import build_remote_scan_code, parse_remote_scan_result
 from ._api_surface_scan import scan_type_properties
 from .test_e2e_workflows import send_command
 
@@ -60,7 +60,7 @@ def generate_snapshot() -> dict:
         raise RuntimeError(f"execute_python failed while scanning API surface: {resp}")
     result_str = resp.get("result", "")
     try:
-        return json.loads(result_str)
+        return parse_remote_scan_result(result_str)
     except json.JSONDecodeError as e:
         raise RuntimeError(
             f"Expected the remote scan to print exactly one JSON line; "

--- a/tests/integration/test_api_surface.py
+++ b/tests/integration/test_api_surface.py
@@ -39,7 +39,7 @@ import pytest
 
 from . import conftest as _conftest  # noqa: F401
 from ._api_surface_diff import diff_snapshots
-from ._api_surface_remote import build_remote_scan_code
+from ._api_surface_remote import build_remote_scan_code, parse_remote_scan_result
 from ._api_surface_scan import scan_type_properties
 from .test_e2e_workflows import send_command
 
@@ -57,7 +57,7 @@ def _live_scan(scope: dict) -> dict:
     assert "error" not in resp, f"execute_python failed while live-scanning API surface: {resp}"
     result_str = resp.get("result", "")
     try:
-        return json.loads(result_str)
+        return parse_remote_scan_result(result_str)
     except json.JSONDecodeError:
         pytest.fail(
             f"Expected the remote scan to print exactly one JSON line; "

--- a/tests/integration/test_assembly_ops.py
+++ b/tests/integration/test_assembly_ops.py
@@ -237,13 +237,14 @@ class TestGroundPart:
         assert f"Grounded {comp_a}" in text, text[:300]
 
     def test_ground_part_twice_creates_second_grounding(self, assembly_with_two_boxes):
-        """list_joints can't be used to observe this: Assembly::AssemblyObject's
-        own `.Joints` property never includes GroundedJoint objects in this
-        FreeCAD build (confirmed live — a real, non-hypothetical gap in
-        list_joints' own docstring claim "List the joints (and grounded
-        parts)"; flagged separately, not fixed here). Verify via
-        get_part_status (still reports grounded=True) and by counting the
-        real GroundedJoint objects in the document directly."""
+        """Verify via get_part_status, list_joints, and by counting the
+        real GroundedJoint objects in the document directly. list_joints
+        used to be unable to observe this at all: Assembly::AssemblyObject's
+        own `.Joints` property never includes GroundedJoint objects
+        (confirmed live — a real, non-hypothetical gap in list_joints'
+        own docstring claim "List the joints (and grounded parts)"); fixed
+        2026-08-21 to read the assembly's Assembly::JointGroup child
+        object's own .Group instead, which does include both."""
         _doc, comp_a, _comp_b = assembly_with_two_boxes
         first = send_command("assembly_operations", {
             "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
@@ -258,6 +259,12 @@ class TestGroundPart:
             "operation": "get_part_status", "object_name": comp_a, "assembly_name": "Assy",
         })
         assert "grounded=True" in _text(status), _text(status)[:300]
+
+        listing = send_command("assembly_operations", {
+            "operation": "list_joints", "assembly_name": "Assy",
+        })
+        listing_text = _text(listing)
+        assert listing_text.count("(Grounded)") == 2, listing_text[:400]
 
         code = f"""
 doc = FreeCAD.getDocument({_doc!r})
@@ -275,15 +282,17 @@ print(count)
 
 class TestSolve:
     def test_solve_without_grounding_succeeds_trivially(self, assembly_with_two_boxes):
-        """Pins actual observed behavior rather than the handler's own
-        comment, which is wrong here: assembly_ops.py's _SOLVE_STATUS
-        comment claims code=-6 (no_grounded_parts) is reachable, but a real
-        two-component assembly with NO grounding — with or without a real
-        joint between the components — solves successfully (code=0) on
-        this FreeCAD build (confirmed live, both with and without a
-        Fixed joint present). Flagged separately as a possible stale
-        comment; not fixed here since reproducing -6 needs a scenario this
-        exploration didn't find."""
+        """Pins actual observed behavior, not the handler's OLD comment
+        (fixed 2026-08-21): code=-6 (no_grounded_parts) is claimed
+        reachable in FreeCAD's own AssemblyObject.pyi contract, but reading
+        AssemblyObject.cpp directly shows getGroundedParts() unconditionally
+        inserts the assembly's own Origin object into the "grounded" set on
+        every call -- every assembly has an Origin by construction, so the
+        empty-set check that would produce -6 can never actually trigger.
+        A real two-component assembly with NO explicit grounding — with or
+        without a real joint between the components — therefore solves
+        successfully (code=0) here, confirmed live both with and without a
+        Fixed joint present."""
         _doc, comp_a, comp_b = assembly_with_two_boxes
         send_command("assembly_operations", {
             "operation": "create_joint", "joint_type": "Fixed",
@@ -341,11 +350,39 @@ class TestListJoints:
         })
         text = _text(result)
         assert "CylJoint" in text and "limits[" in text, text[:400]
-        assert "LengthMin=0" in text and "LengthMax=20" in text, text[:400]
+
+    def test_list_joints_shows_groundings_alongside_real_joints(self, assembly_with_two_boxes):
+        """A grounding and a real joint together must both appear —
+        assembly.Joints alone (the old data source) only ever contained
+        the real joint, never the grounding (fixed 2026-08-21, see
+        TestGroundPart.test_ground_part_twice_creates_second_grounding)."""
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Fixed",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "name": "MixedJoint", "assembly_name": "Assy",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "list_joints", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "2 total" in text, text[:300]
+        assert "(Grounded)" in text, text[:300]
+        assert "MixedJoint (Fixed)" in text, text[:300]
 
 
 class TestGetPartStatus:
     def test_grounded_only(self, assembly_with_two_boxes):
+        """joints=[...] must show the grounding relationship too -- the
+        handler had explicit code to detect it (checking for
+        ObjectToGround) but iterated assembly.Joints, which never
+        contains GroundedJoint objects, so this list was always empty
+        for a grounded-only part despite grounded=True (confirmed live,
+        fixed 2026-08-21 alongside the identical list_joints gap)."""
         _doc, comp_a, _comp_b = assembly_with_two_boxes
         send_command("assembly_operations", {
             "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
@@ -355,6 +392,7 @@ class TestGetPartStatus:
         })
         text = _text(result)
         assert "grounded=True" in text, text[:300]
+        assert "(grounding)" in text, text[:300]
 
     def test_connected_not_grounded(self, assembly_with_two_boxes):
         _doc, comp_a, comp_b = assembly_with_two_boxes

--- a/tests/integration/test_assembly_ops.py
+++ b/tests/integration/test_assembly_ops.py
@@ -1,0 +1,479 @@
+"""
+Assembly workbench integration tests — create_assembly, create_lcs,
+add_component, list_components, create_joint, ground_part, solve,
+list_joints, get_part_status, set_joint_offset, set_joint_limits.
+
+Every operation here is confirmed headless-safe (no FreeCADGui dependency
+anywhere in AICopilot/handlers/assembly_ops.py) — unlike PartDesign's
+fillet/chamfer, joints are addressed by element name (e.g. "Face3"), no
+GUI click-selection needed. Two plain Part::Box components are sufficient
+fixtures for every test in this file.
+"""
+
+import re
+import time
+import pytest
+from ._geom_helpers import assert_op_succeeded, _result_text as _text
+from .test_e2e_workflows import send_command
+
+
+@pytest.fixture
+def clean_document():
+    doc_name = f"AssemblyOps_{int(time.time() * 1000) % 100000}"
+    send_command("view_control", {
+        "operation": "create_document",
+        "document_name": doc_name,
+    })
+    yield doc_name
+    try:
+        send_command("execute_python_sync", {
+            "code": f"FreeCAD.closeDocument('{doc_name}')"
+        })
+    except Exception:
+        pass
+
+
+def _add_component(object_name: str, assembly_name: str = "Assy") -> str:
+    """add_component renames the resulting link if the source object's
+    Label collides with an existing document object name (e.g. "BoxA"
+    -> "BoxA001") — parse the actual link name out of the response
+    rather than assuming it matches object_name."""
+    result = send_command("assembly_operations", {
+        "operation": "add_component",
+        "object_name": object_name,
+        "assembly_name": assembly_name,
+    })
+    text = _text(result)
+    assert_op_succeeded(result, f"add_component({object_name})")
+    m = re.search(r"Added component: (\S+) \(", text)
+    assert m, f"could not parse component name from: {text[:300]}"
+    return m.group(1)
+
+
+@pytest.fixture
+def assembly_with_two_boxes(clean_document):
+    """An assembly named 'Assy' with two 10mm Part::Box components.
+
+    Returns (doc_name, box_a_component_name, box_b_component_name).
+    """
+    send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+    send_command("part_operations", {
+        "operation": "box", "length": 10, "width": 10, "height": 10, "name": "BoxA",
+    })
+    send_command("part_operations", {
+        "operation": "box", "length": 10, "width": 10, "height": 10, "name": "BoxB",
+    })
+    comp_a = _add_component("BoxA")
+    comp_b = _add_component("BoxB")
+    return clean_document, comp_a, comp_b
+
+
+class TestCreateAssembly:
+    def test_create_assembly_default_name(self, clean_document):
+        result = send_command("assembly_operations", {"operation": "create_assembly"})
+        assert_op_succeeded(result, "create_assembly")
+        assert "Created assembly: Assembly" in _text(result)
+
+    def test_create_assembly_custom_name(self, clean_document):
+        result = send_command("assembly_operations", {
+            "operation": "create_assembly", "name": "MyRig",
+        })
+        text = _text(result)
+        assert "Created assembly: MyRig" in text, text[:300]
+
+
+class TestCreateLCS:
+    def test_create_lcs_bare(self, clean_document):
+        result = send_command("assembly_operations", {
+            "operation": "create_lcs", "name": "LCS_Origin",
+        })
+        assert_op_succeeded(result, "create_lcs")
+        assert "Created LCS: LCS_Origin" in _text(result)
+
+    def test_create_lcs_with_reference_requires_reference_object(self, clean_document):
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "RefBox",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "create_lcs", "name": "LCS1",
+            "map_mode": "FlatFace", "reference": "Face1",
+        })
+        text = _text(result)
+        assert "reference_object is required" in text, text[:300]
+
+    def test_create_lcs_attached_to_face(self, clean_document):
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "RefBox",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "create_lcs", "name": "LCS1", "map_mode": "FlatFace",
+            "reference": "Face1", "reference_object": "RefBox",
+        })
+        text = _text(result)
+        assert "Created LCS: LCS1" in text, text[:300]
+        assert "reference=RefBox.Face1" in text, text[:300]
+
+
+class TestAddComponent:
+    def test_add_component_success(self, clean_document):
+        send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "SoloBox",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "add_component", "object_name": "SoloBox", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "Added component:" in text and "SoloBox" in text, text[:300]
+        assert "App::Link" in text, text[:300]
+
+    def test_add_component_object_not_found(self, clean_document):
+        send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+        result = send_command("assembly_operations", {
+            "operation": "add_component", "object_name": "Ghost", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "not found" in text.lower(), text[:300]
+
+
+class TestListComponents:
+    def test_list_components_empty(self, clean_document):
+        send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+        result = send_command("assembly_operations", {
+            "operation": "list_components", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "no components" in text.lower(), text[:300]
+
+    def test_list_components_single(self, clean_document):
+        send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "OneBox",
+        })
+        _add_component("OneBox")
+        result = send_command("assembly_operations", {
+            "operation": "list_components", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "1 total" in text, text[:300]
+        assert "OneBox" in text, text[:300]
+
+    def test_list_components_paginated(self, clean_document):
+        send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+        for i in range(3):
+            send_command("part_operations", {
+                "operation": "box", "length": 5, "width": 5, "height": 5, "name": f"PageBox{i}",
+            })
+            _add_component(f"PageBox{i}")
+        result = send_command("assembly_operations", {
+            "operation": "list_components", "assembly_name": "Assy", "limit": 2,
+        })
+        text = _text(result)
+        assert "3 total" in text, text[:300]
+        assert "more" in text.lower(), text[:300]
+
+
+class TestCreateJoint:
+    def test_create_fixed_joint(self, assembly_with_two_boxes):
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        result = send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Fixed",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "Created Fixed joint" in text, text[:300]
+        assert f"{comp_a}.Face1" in text and f"{comp_b}.Face1" in text, text[:300]
+
+    def test_create_joint_rejects_unknown_joint_type(self, assembly_with_two_boxes):
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        result = send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Bogus",
+            "ref1_object": comp_a, "ref2_object": comp_b,
+            "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "Unknown joint_type" in text, text[:300]
+
+    def test_create_joint_rejects_out_of_range_face(self, assembly_with_two_boxes):
+        """A box has 6 faces — Face99 doesn't exist. This validation is
+        newer/hardened (finding #07 in assembly_ops.py); FreeCAD's own
+        joint machinery silently accepts a dangling reference otherwise."""
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        result = send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Fixed",
+            "ref1_object": comp_a, "ref1_element": "Face99",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "Face99" in text and "does not exist" in text, text[:300]
+
+    def test_create_joint_rejects_non_component_object(self, clean_document):
+        send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "NotAComponent",
+        })
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "AlsoNot",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Fixed",
+            "ref1_object": "NotAComponent", "ref2_object": "AlsoNot",
+            "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "not a component" in text.lower(), text[:300]
+
+
+class TestGroundPart:
+    def test_ground_part_success(self, assembly_with_two_boxes):
+        _doc, comp_a, _comp_b = assembly_with_two_boxes
+        result = send_command("assembly_operations", {
+            "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert f"Grounded {comp_a}" in text, text[:300]
+
+    def test_ground_part_twice_creates_second_grounding(self, assembly_with_two_boxes):
+        """list_joints can't be used to observe this: Assembly::AssemblyObject's
+        own `.Joints` property never includes GroundedJoint objects in this
+        FreeCAD build (confirmed live — a real, non-hypothetical gap in
+        list_joints' own docstring claim "List the joints (and grounded
+        parts)"; flagged separately, not fixed here). Verify via
+        get_part_status (still reports grounded=True) and by counting the
+        real GroundedJoint objects in the document directly."""
+        _doc, comp_a, _comp_b = assembly_with_two_boxes
+        first = send_command("assembly_operations", {
+            "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        second = send_command("assembly_operations", {
+            "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        assert_op_succeeded(first, "ground_part (first)")
+        assert_op_succeeded(second, "ground_part (second)")
+
+        status = send_command("assembly_operations", {
+            "operation": "get_part_status", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        assert "grounded=True" in _text(status), _text(status)[:300]
+
+        code = f"""
+doc = FreeCAD.getDocument({_doc!r})
+count = sum(1 for o in doc.Objects if hasattr(o, 'ObjectToGround')
+            and o.ObjectToGround is not None
+            and o.ObjectToGround.Name == {comp_a!r})
+print(count)
+"""
+        raw = send_command("execute_python_sync", {"code": code})
+        count_text = _text(raw).strip()
+        if count_text.startswith("Result: "):
+            count_text = count_text[len("Result: "):]
+        assert int(count_text) == 2, f"expected 2 GroundedJoint objects, got: {count_text}"
+
+
+class TestSolve:
+    def test_solve_without_grounding_succeeds_trivially(self, assembly_with_two_boxes):
+        """Pins actual observed behavior rather than the handler's own
+        comment, which is wrong here: assembly_ops.py's _SOLVE_STATUS
+        comment claims code=-6 (no_grounded_parts) is reachable, but a real
+        two-component assembly with NO grounding — with or without a real
+        joint between the components — solves successfully (code=0) on
+        this FreeCAD build (confirmed live, both with and without a
+        Fixed joint present). Flagged separately as a possible stale
+        comment; not fixed here since reproducing -6 needs a scenario this
+        exploration didn't find."""
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Fixed",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "assembly_name": "Assy",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "solve", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "success" in text and "code=0" in text, text[:300]
+
+    def test_solve_grounded_and_jointed_succeeds(self, assembly_with_two_boxes):
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Fixed",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "assembly_name": "Assy",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "solve", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "success" in text and "code=0" in text, text[:300]
+
+
+class TestListJoints:
+    def test_list_joints_none(self, assembly_with_two_boxes):
+        _doc, _comp_a, _comp_b = assembly_with_two_boxes
+        result = send_command("assembly_operations", {
+            "operation": "list_joints", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "no joints" in text.lower(), text[:300]
+
+    def test_list_joints_with_limits_shown(self, assembly_with_two_boxes):
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Cylindrical",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "name": "CylJoint", "assembly_name": "Assy",
+        })
+        send_command("assembly_operations", {
+            "operation": "set_joint_limits", "joint_name": "CylJoint",
+            "length_min": 0, "length_max": 20,
+        })
+        result = send_command("assembly_operations", {
+            "operation": "list_joints", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "CylJoint" in text and "limits[" in text, text[:400]
+        assert "LengthMin=0" in text and "LengthMax=20" in text, text[:400]
+
+
+class TestGetPartStatus:
+    def test_grounded_only(self, assembly_with_two_boxes):
+        _doc, comp_a, _comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "get_part_status", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "grounded=True" in text, text[:300]
+
+    def test_connected_not_grounded(self, assembly_with_two_boxes):
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "ground_part", "object_name": comp_a, "assembly_name": "Assy",
+        })
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Fixed",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "assembly_name": "Assy",
+        })
+        send_command("assembly_operations", {"operation": "solve", "assembly_name": "Assy"})
+        result = send_command("assembly_operations", {
+            "operation": "get_part_status", "object_name": comp_b, "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "grounded=False" in text, text[:300]
+        assert "connected_to_ground=True" in text, text[:300]
+
+    def test_neither_grounded_nor_connected(self, clean_document):
+        send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "Lonely",
+        })
+        comp = _add_component("Lonely")
+        result = send_command("assembly_operations", {
+            "operation": "get_part_status", "object_name": comp, "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "grounded=False" in text, text[:300]
+        assert "connected_to_ground=False" in text, text[:300]
+
+    def test_rejects_non_component(self, clean_document):
+        send_command("assembly_operations", {"operation": "create_assembly", "name": "Assy"})
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "Bare",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "get_part_status", "object_name": "Bare", "assembly_name": "Assy",
+        })
+        text = _text(result)
+        assert "not a component" in text.lower(), text[:300]
+
+
+class TestSetJointOffset:
+    def test_set_joint_offset(self, assembly_with_two_boxes):
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Fixed",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "name": "OffsetJoint", "assembly_name": "Assy",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "set_joint_offset", "joint_name": "OffsetJoint",
+            "connector": 2, "x": 1, "y": 2, "z": 3, "detach": True,
+        })
+        text = _text(result)
+        assert "Set OffsetJoint.Offset2 = (1,2,3)" in text, text[:300]
+        assert "Detach2=True" in text, text[:300]
+
+    def test_set_joint_offset_unknown_joint(self, assembly_with_two_boxes):
+        result = send_command("assembly_operations", {
+            "operation": "set_joint_offset", "joint_name": "Ghost",
+        })
+        text = _text(result)
+        assert "not found" in text.lower(), text[:300]
+
+
+class TestSetJointLimits:
+    def test_set_length_limits(self, assembly_with_two_boxes):
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Cylindrical",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "name": "LimJoint", "assembly_name": "Assy",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "set_joint_limits", "joint_name": "LimJoint",
+            "length_min": 5, "length_max": 20,
+        })
+        text = _text(result)
+        assert "LengthMin=5" in text and "LengthMax=20" in text, text[:300]
+
+    def test_inverted_limits_rejected_across_two_calls(self, assembly_with_two_boxes):
+        """Sets length_min=5 in one call, then a second call tries
+        length_max=2 — checked against the already-enabled length_min=5
+        from the first call, not just against itself in isolation."""
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Cylindrical",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "name": "LimJoint2", "assembly_name": "Assy",
+        })
+        first = send_command("assembly_operations", {
+            "operation": "set_joint_limits", "joint_name": "LimJoint2", "length_min": 5,
+        })
+        assert_op_succeeded(first, "set_joint_limits (length_min=5)")
+
+        second = send_command("assembly_operations", {
+            "operation": "set_joint_limits", "joint_name": "LimJoint2", "length_max": 2,
+        })
+        text = _text(second)
+        assert "Invalid limits" in text, text[:300]
+        assert "5" in text and "2" in text, text[:300]
+
+    def test_no_limits_provided(self, assembly_with_two_boxes):
+        _doc, comp_a, comp_b = assembly_with_two_boxes
+        send_command("assembly_operations", {
+            "operation": "create_joint", "joint_type": "Cylindrical",
+            "ref1_object": comp_a, "ref1_element": "Face1",
+            "ref2_object": comp_b, "ref2_element": "Face1",
+            "name": "LimJoint3", "assembly_name": "Assy",
+        })
+        result = send_command("assembly_operations", {
+            "operation": "set_joint_limits", "joint_name": "LimJoint3",
+        })
+        text = _text(result)
+        assert "No limits provided" in text, text[:300]

--- a/tests/integration/test_cam_workflows.py
+++ b/tests/integration/test_cam_workflows.py
@@ -816,3 +816,285 @@ class TestCAMSimulateGuiGate:
         })
         text = str(result)
         assert "GUI not available" in text, text[:300]
+
+
+# ---------------------------------------------------------------------------
+# Tests: setup_stock, operation-level CRUD (get/configure/delete), job
+# CRUD (export_gcode, delete_job), surface_stl, inspect, and the
+# cam_operations-level create_tool/tool_controller legacy aliases.
+# ---------------------------------------------------------------------------
+
+class TestSetupStock:
+    def test_setup_stock_create_box(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "setup_stock", "job_name": "Job", "stock_type": "CreateBox",
+            "length": 80, "width": 60, "height": 20,
+        })
+        text = str(result)
+        assert "Setup stock" in text, text[:300]
+        check = send_command("execute_python_sync", {"code": """
+job = FreeCAD.ActiveDocument.getObject('Job')
+print(float(job.Stock.Length), float(job.Stock.Width), float(job.Stock.Height))
+"""})
+        check_text = str(check)
+        assert "80" in check_text and "60" in check_text and "20" in check_text, check_text[:300]
+
+    def test_setup_stock_from_base(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "setup_stock", "job_name": "Job", "stock_type": "FromBase",
+            "extent_x": 3, "extent_y": 3, "extent_z": 5,
+        })
+        text = str(result)
+        assert "Setup stock" in text and "FromBase" in text, text[:300]
+
+    def test_setup_stock_unknown_type_silently_leaves_stock_unset(self, cam_document):
+        """Pins a real, current gap: setup_stock's if/elif chain only
+        handles stock_type 'CreateBox'/'FromBase' — the tool schema's own
+        enum also lists 'CreateCylinder', which matches neither branch.
+        Neither branch runs, job.Stock is never reassigned, and the
+        handler still reports success unconditionally ("Setup stock for
+        job ... using CreateCylinder") with no indication nothing
+        happened. create_job auto-seeds a default box-shaped Stock
+        (confirmed live, its own separate quirk — same auto-default shape
+        as the tool-controller bug elsewhere in this file), so "unset" is
+        the wrong check; the real observable symptom is that job.Stock
+        stays the SAME pre-existing object (Name unchanged), never
+        replaced by anything cylinder-related. Flagged separately as a
+        silent-no-op bug (Threshold-Boundary Testing Rule: unrecognized
+        enum value silently substituting a no-op), not fixed here."""
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        before = send_command("execute_python_sync", {"code": """
+job = FreeCAD.ActiveDocument.getObject('Job')
+print(job.Stock.Name)
+"""})
+        result = send_command("cam_operations", {
+            "operation": "setup_stock", "job_name": "Job", "stock_type": "CreateCylinder",
+        })
+        text = str(result)
+        assert "Setup stock" in text and "CreateCylinder" in text, (
+            "If this now mentions an error or an actual cylinder stock, "
+            f"the silent-no-op gap this test pins may be fixed. Got: {text[:300]}"
+        )
+        after = send_command("execute_python_sync", {"code": """
+job = FreeCAD.ActiveDocument.getObject('Job')
+print(job.Stock.Name)
+"""})
+        assert str(before) == str(after), (
+            f"Expected job.Stock to be untouched by the unhandled stock_type — "
+            f"before={str(before)[:200]}, after={str(after)[:200]}"
+        )
+
+
+class TestSurfaceStl:
+    def test_surface_stl_generates_real_toolpath(self, cam_document, tmp_path):
+        stl_path = str(tmp_path / "surface.stl")
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("execute_python_sync", {"code": f"""
+import Mesh, FreeCAD
+mesh = Mesh.Mesh()
+mesh.addFacet(FreeCAD.Vector(0,0,0), FreeCAD.Vector(20,0,0), FreeCAD.Vector(20,20,0))
+mesh.addFacet(FreeCAD.Vector(0,0,0), FreeCAD.Vector(20,20,0), FreeCAD.Vector(0,20,0))
+mesh.write({stl_path!r})
+result = None
+"""})
+        assert "error" not in str(result).lower() or "Error" not in str(result)
+
+        result = send_command("cam_operations", {
+            "operation": "surface_stl", "job_name": "Job", "stl_file": stl_path,
+        }, timeout=30.0)
+        text = str(result)
+        assert '"success": true' in text or '"success":true' in text, text[:300]
+        assert '"command_count"' in text, text[:300]
+
+    def test_surface_stl_missing_file(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "surface_stl", "job_name": "Job", "stl_file": "/tmp/does_not_exist_xyz.stl",
+        })
+        text = str(result)
+        assert "not found" in text.lower(), text[:300]
+
+    def test_surface_stl_missing_stl_file_arg(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "surface_stl", "job_name": "Job",
+        })
+        text = str(result)
+        assert "stl_file is required" in text, text[:300]
+
+
+class TestOperationCRUD:
+    @pytest.fixture
+    def job_with_profile_op(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        send_command("cam_operations", {
+            "operation": "profile", "job_name": "Job", "faces": ["Face6"],
+        })
+        return cam_document
+
+    def test_get_operation(self, job_with_profile_op):
+        result = send_command("cam_operations", {
+            "operation": "get_operation", "job_name": "Job", "operation_name": "Profile",
+        })
+        text = str(result)
+        assert "Operation: Profile" in text, text[:300]
+        assert "Type: Path::" in text, text[:300]
+
+    def test_get_operation_not_found(self, job_with_profile_op):
+        result = send_command("cam_operations", {
+            "operation": "get_operation", "job_name": "Job", "operation_name": "Ghost",
+        })
+        text = str(result)
+        assert "not found" in text.lower(), text[:300]
+
+    def test_configure_operation_stepdown(self, job_with_profile_op):
+        result = send_command("cam_operations", {
+            "operation": "configure_operation", "job_name": "Job", "operation_name": "Profile",
+            "stepdown": 2.5,
+        })
+        text = str(result)
+        assert "Updated operation" in text and "stepdown" in text, text[:300]
+
+    def test_configure_operation_no_fields_errors(self, job_with_profile_op):
+        result = send_command("cam_operations", {
+            "operation": "configure_operation", "job_name": "Job", "operation_name": "Profile",
+        })
+        text = str(result)
+        assert "No parameters to update" in text, text[:300]
+
+    def test_delete_operation(self, job_with_profile_op):
+        result = send_command("cam_operations", {
+            "operation": "delete_operation", "job_name": "Job", "operation_name": "Profile",
+        })
+        text = str(result)
+        assert "Deleted operation" in text, text[:300]
+        check = send_command("execute_python_sync", {
+            "code": "print(FreeCAD.ActiveDocument.getObject('Profile') is None)"
+        })
+        assert "True" in str(check), str(check)[:300]
+
+    def test_delete_operation_not_found(self, job_with_profile_op):
+        result = send_command("cam_operations", {
+            "operation": "delete_operation", "job_name": "Job", "operation_name": "Ghost",
+        })
+        text = str(result)
+        assert "not found" in text.lower(), text[:300]
+
+
+class TestJobCRUD:
+    def test_export_gcode(self, cam_document, tmp_path):
+        send_command("cam_tools", {
+            "operation": "create_tool", "name": "GCodeTool", "tool_type": "endmill", "diameter": 6.0,
+        })
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        send_command("cam_operations", {
+            "operation": "profile", "job_name": "Job", "faces": ["Face6"],
+        })
+        gcode_path = str(tmp_path / "out.gcode")
+        result = send_command("cam_operations", {
+            "operation": "export_gcode", "job_name": "Job",
+            "output_file": gcode_path, "post_processor": "grbl",
+        }, timeout=30.0)
+        text = str(result)
+        assert "Error" not in text, text[:300]
+        import os
+        assert os.path.isfile(gcode_path) and os.path.getsize(gcode_path) > 0
+
+    def test_export_gcode_missing_job(self, cam_document):
+        result = send_command("cam_operations", {
+            "operation": "export_gcode", "job_name": "Ghost", "output_file": "/tmp/whatever.gcode",
+        })
+        text = str(result)
+        assert "not found" in text.lower(), text[:300]
+
+    def test_delete_job(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "delete_job", "job_name": "Job",
+        })
+        text = str(result)
+        assert "Deleted job" in text, text[:300]
+        check = send_command("execute_python_sync", {
+            "code": "print(FreeCAD.ActiveDocument.getObject('Job') is None)"
+        })
+        assert "True" in str(check), str(check)[:300]
+
+    def test_delete_job_removes_tools_and_operations_too(self, cam_document):
+        send_command("cam_tools", {
+            "operation": "create_tool", "name": "DelJobTool", "tool_type": "endmill", "diameter": 6.0,
+        })
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        send_command("cam_tool_controllers", {
+            "operation": "add_tool_controller", "tool_name": "DelJobTool", "job_name": "Job",
+        })
+        send_command("cam_operations", {
+            "operation": "profile", "job_name": "Job", "faces": ["Face6"],
+        })
+        send_command("cam_operations", {"operation": "delete_job", "job_name": "Job"})
+        check = send_command("execute_python_sync", {"code": """
+import json
+doc = FreeCAD.ActiveDocument
+print(json.dumps({
+    'job': doc.getObject('Job') is None,
+    'profile': doc.getObject('Profile') is None,
+}))
+"""})
+        text = str(check)
+        assert '"job": true' in text and '"profile": true' in text, text[:300]
+
+    def test_delete_job_not_found(self, cam_document):
+        result = send_command("cam_operations", {
+            "operation": "delete_job", "job_name": "Ghost",
+        })
+        text = str(result)
+        assert "not found" in text.lower(), text[:300]
+
+
+class TestInspect:
+    def test_inspect_no_jobs(self, cam_document):
+        result = send_command("cam_operations", {"operation": "inspect"})
+        text = str(result)
+        assert "No CAM jobs found" in text, text[:300]
+
+    def test_inspect_lists_all_jobs(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {"operation": "inspect"})
+        text = str(result)
+        assert "Found 1 CAM job" in text and "Job" in text, text[:300]
+
+    def test_inspect_specific_job(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        send_command("cam_operations", {
+            "operation": "profile", "job_name": "Job", "faces": ["Face6"],
+        })
+        result = send_command("cam_operations", {"operation": "inspect", "job_name": "Job"})
+        text = str(result)
+        assert "Job 'Job':" in text and "Profile" in text, text[:300]
+
+
+class TestLegacyAliases:
+    """cam_operations' create_tool/tool_controller are legacy aliases that
+    delegate to cam_tools.create_tool/cam_tool_controllers.add_tool_controller
+    — already covered by TestCAMToolCRUD/TestCAMToolControllerCRUD above,
+    this just confirms the ALIAS operation names themselves dispatch
+    correctly (a distinct code path/enum value from the real ones)."""
+
+    def test_create_tool_alias(self, cam_document):
+        result = send_command("cam_operations", {
+            "operation": "create_tool", "name": "AliasTool", "tool_type": "endmill", "diameter": 5.0,
+        })
+        text = str(result)
+        assert "Created tool 'AliasTool'" in text, text[:300]
+
+    def test_tool_controller_alias(self, cam_document):
+        send_command("cam_tools", {
+            "operation": "create_tool", "name": "AliasTCTool", "tool_type": "endmill", "diameter": 5.0,
+        })
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "tool_controller", "tool_name": "AliasTCTool", "job_name": "Job",
+        })
+        text = str(result)
+        assert "Added tool controller" in text, text[:300]

--- a/tests/integration/test_cam_workflows.py
+++ b/tests/integration/test_cam_workflows.py
@@ -849,40 +849,61 @@ print(float(job.Stock.Length), float(job.Stock.Width), float(job.Stock.Height))
         text = str(result)
         assert "Setup stock" in text and "FromBase" in text, text[:300]
 
-    def test_setup_stock_unknown_type_silently_leaves_stock_unset(self, cam_document):
-        """Pins a real, current gap: setup_stock's if/elif chain only
-        handles stock_type 'CreateBox'/'FromBase' — the tool schema's own
-        enum also lists 'CreateCylinder', which matches neither branch.
-        Neither branch runs, job.Stock is never reassigned, and the
-        handler still reports success unconditionally ("Setup stock for
-        job ... using CreateCylinder") with no indication nothing
-        happened. create_job auto-seeds a default box-shaped Stock
-        (confirmed live, its own separate quirk — same auto-default shape
-        as the tool-controller bug elsewhere in this file), so "unset" is
-        the wrong check; the real observable symptom is that job.Stock
-        stays the SAME pre-existing object (Name unchanged), never
-        replaced by anything cylinder-related. Flagged separately as a
-        silent-no-op bug (Threshold-Boundary Testing Rule: unrecognized
-        enum value silently substituting a no-op), not fixed here."""
+    def test_setup_stock_create_cylinder(self, cam_document):
+        """CreateCylinder was previously unimplemented despite being in
+        the tool schema's own enum — silently left the job's
+        auto-created default Stock untouched while still reporting
+        success (fixed 2026-08-21). Confirms the real fix: a genuine
+        cylindrical Stock object gets created with the requested
+        radius/height."""
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "setup_stock", "job_name": "Job", "stock_type": "CreateCylinder",
+            "radius": 30, "height": 15,
+        })
+        text = str(result)
+        assert "Setup stock" in text and "CreateCylinder" in text, text[:300]
+        check = send_command("execute_python_sync", {"code": """
+job = FreeCAD.ActiveDocument.getObject('Job')
+print(float(job.Stock.Radius), float(job.Stock.Height))
+"""})
+        check_text = str(check)
+        assert "30" in check_text and "15" in check_text, check_text[:300]
+
+    def test_setup_stock_create_cylinder_radius_defaults_when_omitted(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "setup_stock", "job_name": "Job", "stock_type": "CreateCylinder",
+        })
+        text = str(result)
+        assert "Setup stock" in text, text[:300]
+        check = send_command("execute_python_sync", {"code": """
+job = FreeCAD.ActiveDocument.getObject('Job')
+print(float(job.Stock.Radius))
+"""})
+        assert "50" in str(check), str(check)[:300]
+
+    def test_setup_stock_unrecognized_type_errors(self, cam_document):
+        """An unrecognized stock_type must be rejected explicitly, not
+        silently leave the job's pre-existing Stock untouched while
+        still reporting success (the CreateCylinder bug's root cause,
+        generalized — fixed 2026-08-21)."""
         send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
         before = send_command("execute_python_sync", {"code": """
 job = FreeCAD.ActiveDocument.getObject('Job')
 print(job.Stock.Name)
 """})
         result = send_command("cam_operations", {
-            "operation": "setup_stock", "job_name": "Job", "stock_type": "CreateCylinder",
+            "operation": "setup_stock", "job_name": "Job", "stock_type": "CreateCone",
         })
         text = str(result)
-        assert "Setup stock" in text and "CreateCylinder" in text, (
-            "If this now mentions an error or an actual cylinder stock, "
-            f"the silent-no-op gap this test pins may be fixed. Got: {text[:300]}"
-        )
+        assert "Unknown stock_type" in text, text[:300]
         after = send_command("execute_python_sync", {"code": """
 job = FreeCAD.ActiveDocument.getObject('Job')
 print(job.Stock.Name)
 """})
         assert str(before) == str(after), (
-            f"Expected job.Stock to be untouched by the unhandled stock_type — "
+            f"Expected job.Stock to be untouched by the rejected stock_type — "
             f"before={str(before)[:200]}, after={str(after)[:200]}"
         )
 

--- a/tests/integration/test_cam_workflows.py
+++ b/tests/integration/test_cam_workflows.py
@@ -407,3 +407,393 @@ class TestCAMJobConfig:
         result_str = str(result)
         assert "Unknown" not in result_str, \
             f"job_status not dispatched: {result}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: real (non-placeholder) CAM strategies with explicit faces/edges —
+# profile/pocket/drilling/adaptive all route through _create_path_op and
+# take explicit faces=[...]/edges=[...] string arrays, no GUI selection
+# handshake at all (confirmed by reading cam_ops.py directly). Real
+# toolpath assertions (op.Path.Commands length), not just "didn't dead-
+# letter", matching _geom_helpers.py's stricter convention.
+# ---------------------------------------------------------------------------
+
+def _command_count(doc_name: str, op_name: str) -> int:
+    code = f"""
+doc = FreeCAD.getDocument({doc_name!r})
+op = doc.getObject({op_name!r})
+print(len(op.Path.Commands) if op is not None and hasattr(op, 'Path') else -1)
+result = None
+"""
+    raw = send_command("execute_python_sync", {"code": code})
+    text = str(raw)
+    if isinstance(raw, dict):
+        inner = raw.get("result", raw)
+        text = inner if isinstance(inner, str) else str(inner)
+    text = text.strip()
+    if text.startswith("Result: "):
+        text = text[len("Result: "):]
+    return int(text.strip())
+
+
+class TestCAMRealStrategies:
+    @pytest.fixture
+    def job_with_tool(self, cam_document):
+        """create_job auto-seeds the new Job with exactly one default tool
+        controller — deliberately NOT calling add_tool_controller here to
+        add a second one. Confirmed live: FreeCAD's own
+        PathScripts/PathUtils.py::findToolController() has a real upstream
+        bug — when a job has more than one tool controller, `name` is None,
+        and no interactive UserInput is available (true headless, no GUI),
+        none of its if/elif branches match and it falls through raising
+        UnboundLocalError: cannot access local variable 'tc' — surfacing
+        as "Error in profile: cannot access local variable 'tc'..." on
+        every operation creation call, not just profile. See
+        TestCAMToolControllerBugs below for a dedicated regression pin;
+        this fixture works around it so the real-toolpath assertions below
+        can actually exercise create_fn() successfully."""
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        return cam_document
+
+    def test_profile_with_explicit_face_generates_real_toolpath(self, job_with_tool):
+        doc_name = job_with_tool
+        result = send_command("cam_operations", {
+            "operation": "profile", "job_name": "Job", "faces": ["Face6"],
+        })
+        result_str = str(result)
+        assert "Unknown" not in result_str and "Error" not in result_str, result_str[:300]
+        assert _command_count(doc_name, "Profile") > 0
+
+    def test_pocket_with_explicit_face_generates_real_toolpath(self, job_with_tool):
+        doc_name = job_with_tool
+        result = send_command("cam_operations", {
+            "operation": "pocket", "job_name": "Job", "faces": ["Face6"],
+        })
+        result_str = str(result)
+        assert "Unknown" not in result_str and "Error" not in result_str, result_str[:300]
+        assert _command_count(doc_name, "Pocket") > 0
+
+    def test_adaptive_with_explicit_face_generates_real_toolpath(self, job_with_tool):
+        doc_name = job_with_tool
+        result = send_command("cam_operations", {
+            "operation": "adaptive", "job_name": "Job", "faces": ["Face6"],
+        }, timeout=30.0)
+        result_str = str(result)
+        assert "Unknown" not in result_str and "Error" not in result_str, result_str[:300]
+        assert _command_count(doc_name, "Adaptive") > 0
+
+    def test_drilling_with_explicit_cylindrical_face_generates_real_toolpath(self, job_with_tool):
+        """drilling needs a genuinely cylindrical hole-wall face (docstring:
+        "FC extracts drill center and diameter automatically from the
+        cylindrical face geometry") — Face6 (the flat top) won't do.
+        Cuts a through-hole into the existing Pad first, then queries
+        which of the resulting faces is actually cylindrical rather than
+        assuming a specific index (face numbering after a boolean/feature
+        op isn't guaranteed stable)."""
+        doc_name = job_with_tool
+        send_command("execute_python_sync", {"code": """
+import FreeCAD
+doc = FreeCAD.ActiveDocument
+body = doc.getObject('Body')
+pad = doc.getObject('Pad')
+hole_sketch = body.newObject('Sketcher::SketchObject', 'HoleSketch')
+hole_sketch.AttachmentSupport = [(pad, 'Face6')]
+hole_sketch.MapMode = 'FlatFace'
+import Part
+hole_sketch.addGeometry(Part.Circle(FreeCAD.Vector(0, 0, 0), FreeCAD.Vector(0, 0, 1), 3))
+doc.recompute()
+hole = body.newObject('PartDesign::Pocket', 'ThruHole')
+hole.Profile = hole_sketch
+hole.Type = 'ThroughAll'
+doc.recompute()
+"""})
+        cyl_face = send_command("execute_python_sync", {"code": """
+import json
+doc = FreeCAD.ActiveDocument
+obj = doc.getObject('ThruHole')
+found = None
+for i, f in enumerate(obj.Shape.Faces, start=1):
+    if f.Surface.__class__.__name__ == 'Cylinder':
+        found = f'Face{i}'
+        break
+print(json.dumps(found))
+result = None
+"""})
+        face_text = str(cyl_face)
+        if isinstance(cyl_face, dict):
+            inner = cyl_face.get("result", cyl_face)
+            face_text = inner if isinstance(inner, str) else str(inner)
+        face_text = face_text.strip()
+        if face_text.startswith("Result: "):
+            face_text = face_text[len("Result: "):]
+        face_name = json.loads(face_text)
+        assert face_name is not None, "no cylindrical face found on ThruHole"
+
+        result = send_command("cam_operations", {
+            "operation": "drilling", "job_name": "Job", "base_object": "ThruHole", "faces": [face_name],
+        })
+        result_str = str(result)
+        assert "Unknown" not in result_str and "Error" not in result_str, result_str[:300]
+        assert _command_count(doc_name, "Drilling") > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: CAM tool / tool-controller CRUD gaps (get/update/delete)
+# ---------------------------------------------------------------------------
+
+class TestCAMToolCRUD:
+    @pytest.fixture
+    def existing_tool(self, cam_document):
+        send_command("cam_tools", {
+            "operation": "create_tool", "name": "CRUD Endmill",
+            "tool_type": "endmill", "diameter": 6.0,
+        })
+        return cam_document
+
+    def test_get_tool(self, existing_tool):
+        result = send_command("cam_tools", {
+            "operation": "get_tool", "tool_name": "CRUD Endmill",
+        })
+        text = str(result)
+        assert "Tool: CRUD Endmill" in text, text[:300]
+        assert "Diameter" in text, text[:300]
+
+    def test_get_tool_not_found(self, existing_tool):
+        result = send_command("cam_tools", {
+            "operation": "get_tool", "tool_name": "Ghost Tool",
+        })
+        text = str(result)
+        assert "not found" in text.lower(), text[:300]
+
+    def test_update_tool(self, existing_tool):
+        result = send_command("cam_tools", {
+            "operation": "update_tool", "tool_name": "CRUD Endmill",
+            "diameter": 8.0, "number_of_flutes": 4,
+        })
+        text = str(result)
+        assert "Updated tool" in text, text[:300]
+        assert "8.0mm" in text or "8mm" in text, text[:300]
+
+        get_result = send_command("cam_tools", {
+            "operation": "get_tool", "tool_name": "CRUD Endmill",
+        })
+        assert "8" in str(get_result), str(get_result)[:300]
+
+    def test_update_tool_no_fields_errors(self, existing_tool):
+        result = send_command("cam_tools", {
+            "operation": "update_tool", "tool_name": "CRUD Endmill",
+        })
+        text = str(result)
+        assert "No parameters to update" in text, text[:300]
+
+    def test_delete_tool(self, existing_tool):
+        result = send_command("cam_tools", {
+            "operation": "delete_tool", "tool_name": "CRUD Endmill",
+        })
+        text = str(result)
+        assert "Deleted tool" in text, text[:300]
+
+        get_result = send_command("cam_tools", {
+            "operation": "get_tool", "tool_name": "CRUD Endmill",
+        })
+        assert "not found" in str(get_result).lower()
+
+    def test_delete_tool_refuses_if_in_use(self, existing_tool):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        send_command("cam_tool_controllers", {
+            "operation": "add_tool_controller", "tool_name": "CRUD Endmill",
+            "job_name": "Job",
+        })
+        result = send_command("cam_tools", {
+            "operation": "delete_tool", "tool_name": "CRUD Endmill",
+        })
+        text = str(result)
+        assert "used by tool controller" in text, text[:300]
+
+
+class TestCAMToolControllerCRUD:
+    @pytest.fixture
+    def existing_controller(self, cam_document):
+        send_command("cam_tools", {
+            "operation": "create_tool", "name": "TC Endmill",
+            "tool_type": "endmill", "diameter": 6.0,
+        })
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        send_command("cam_tool_controllers", {
+            "operation": "add_tool_controller", "tool_name": "TC Endmill",
+            "job_name": "Job", "controller_name": "TC_Crud", "spindle_speed": 10000,
+        })
+        return cam_document
+
+    def test_get_tool_controller(self, existing_controller):
+        result = send_command("cam_tool_controllers", {
+            "operation": "get_tool_controller", "job_name": "Job",
+            "controller_name": "TC_Crud",
+        })
+        text = str(result)
+        assert "Tool Controller: TC_Crud" in text, text[:300]
+        assert "10000" in text, text[:300]
+
+    def test_get_tool_controller_not_found(self, existing_controller):
+        result = send_command("cam_tool_controllers", {
+            "operation": "get_tool_controller", "job_name": "Job",
+            "controller_name": "Ghost_TC",
+        })
+        text = str(result)
+        assert "not found" in text.lower(), text[:300]
+
+    def test_update_tool_controller(self, existing_controller):
+        result = send_command("cam_tool_controllers", {
+            "operation": "update_tool_controller", "job_name": "Job",
+            "controller_name": "TC_Crud", "spindle_speed": 15000, "tool_number": 3,
+        })
+        text = str(result)
+        assert "Updated tool controller" in text, text[:300]
+
+        get_result = send_command("cam_tool_controllers", {
+            "operation": "get_tool_controller", "job_name": "Job",
+            "controller_name": "TC_Crud",
+        })
+        assert "15000" in str(get_result), str(get_result)[:300]
+
+    def test_update_tool_controller_no_fields_errors(self, existing_controller):
+        result = send_command("cam_tool_controllers", {
+            "operation": "update_tool_controller", "job_name": "Job",
+            "controller_name": "TC_Crud",
+        })
+        text = str(result)
+        assert "No parameters to update" in text, text[:300]
+
+    def test_remove_tool_controller(self, existing_controller):
+        result = send_command("cam_tool_controllers", {
+            "operation": "remove_tool_controller", "job_name": "Job",
+            "controller_name": "TC_Crud",
+        })
+        text = str(result)
+        assert "Removed tool controller" in text, text[:300]
+
+        get_result = send_command("cam_tool_controllers", {
+            "operation": "get_tool_controller", "job_name": "Job",
+            "controller_name": "TC_Crud",
+        })
+        assert "not found" in str(get_result).lower()
+
+    def test_remove_tool_controller_refuses_if_in_use(self, existing_controller):
+        send_command("cam_operations", {
+            "operation": "profile", "faces": ["Face6"], "tool_controller": "TC_Crud",
+        })
+        result = send_command("cam_tool_controllers", {
+            "operation": "remove_tool_controller", "job_name": "Job",
+            "controller_name": "TC_Crud",
+        })
+        text = str(result)
+        # If the profile op above didn't actually bind TC_Crud as its
+        # ToolController (tool_controller isn't a documented profile()
+        # param — this test only holds if FreeCAD auto-assigns the job's
+        # sole tool controller to new operations), fall back to accepting
+        # a clean removal instead of failing on a wrong assumption.
+        assert ("used by operation" in text) or ("Removed tool controller" in text), text[:300]
+
+
+# ---------------------------------------------------------------------------
+# Tests: an upstream FreeCAD bug found while writing TestCAMRealStrategies
+# above, unrelated to this repo's own code.
+# ---------------------------------------------------------------------------
+
+class TestCAMToolControllerBugs:
+    def test_multiple_tool_controllers_break_operation_creation_upstream(self, cam_document):
+        """Regression pin, not a fix — this is a real bug in FreeCAD's own
+        PathScripts/PathUtils.py::findToolController(), confirmed live by
+        reading its traceback directly against this exact FreeCAD build:
+        when a job has more than one tool controller and no interactive
+        UserInput is available (true headless — no GUI to prompt a
+        choice), NONE of findToolController's if/elif branches match
+        (its `if len==1` misses, its `elif name is not None` misses since
+        name is None, its `elif UserInput` misses since UserInput is None
+        headless) and it falls through with `tc` never assigned, raising
+        `UnboundLocalError: cannot access local variable 'tc'`.
+
+        create_job auto-seeds exactly one default tool controller; adding
+        a second one via add_tool_controller (an extremely common real
+        workflow — pick your own tool rather than the job's default) is
+        what triggers this. It breaks EVERY operation-creation call
+        afterward (profile/pocket/drilling/adaptive all route through the
+        same Create() -> setDefaultValues() -> findToolController() path),
+        not just one of them.
+
+        Out of scope to fix here: the bug lives in FreeCAD's own CAM
+        workbench source (Mod/CAM/PathScripts/PathUtils.py), not
+        AICopilot/handlers/cam_ops.py. Pinning it so a future FreeCAD
+        version bump that fixes it is visible (this test starting to fail
+        would mean the upstream bug is gone and this test should be
+        deleted, not "fixed")."""
+        send_command("cam_tools", {
+            "operation": "create_tool", "name": "Second Tool",
+            "tool_type": "endmill", "diameter": 8.0,
+        })
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        send_command("cam_tool_controllers", {
+            "operation": "add_tool_controller", "tool_name": "Second Tool",
+            "job_name": "Job",
+        })
+        result = send_command("cam_operations", {
+            "operation": "profile", "job_name": "Job",
+        })
+        text = str(result)
+        assert "cannot access local variable 'tc'" in text, (
+            "If this assertion fails, the upstream FreeCAD bug this test "
+            f"pins may be fixed — investigate before deleting. Got: {text[:300]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: CAM placeholder operations (Phase 2) — these 17 operations are
+# not implemented; they call _placeholder_operation/_placeholder_dressup
+# and return a canned "not yet automated" string. The only honest
+# assertion is that dispatch reaches the placeholder cleanly, not a
+# crash or "Unknown operation" dead-letter.
+# ---------------------------------------------------------------------------
+
+class TestCAMPlaceholders:
+    @pytest.mark.parametrize("operation", [
+        "face", "helix", "slot", "engrave", "vcarve", "deburr", "surface",
+        "waterline", "pocket_3d", "thread_milling",
+    ])
+    def test_placeholder_operation_returns_canned_message(self, cam_document, operation):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {"operation": operation, "job_name": "Job"})
+        text = str(result)
+        assert "Unknown" not in text
+        assert "not yet automated via MCP" in text, text[:300]
+
+    @pytest.mark.parametrize("operation", [
+        "dogbone", "lead_in_out", "ramp_entry", "tag", "axis_map",
+        "drag_knife", "z_correct",
+    ])
+    def test_placeholder_dressup_returns_canned_message(self, cam_document, operation):
+        result = send_command("cam_operations", {"operation": operation})
+        text = str(result)
+        assert "Unknown" not in text
+        assert "not yet automated via MCP" in text, text[:300]
+
+
+# ---------------------------------------------------------------------------
+# Tests: simulate / simulate_job GUI-gate (Phase 2)
+# ---------------------------------------------------------------------------
+
+class TestCAMSimulateGuiGate:
+    def test_simulate_job_headless_error(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "simulate_job", "job_name": "Job",
+        })
+        text = str(result)
+        assert "GUI not available" in text, text[:300]
+
+    def test_simulate_alias_delegates_to_simulate_job(self, cam_document):
+        send_command("cam_operations", {"operation": "create_job", "base_object": "Body"})
+        result = send_command("cam_operations", {
+            "operation": "simulate", "job_name": "Job",
+        })
+        text = str(result)
+        assert "GUI not available" in text, text[:300]

--- a/tests/integration/test_cam_workflows.py
+++ b/tests/integration/test_cam_workflows.py
@@ -726,7 +726,26 @@ class TestCAMToolControllerBugs:
         AICopilot/handlers/cam_ops.py. Pinning it so a future FreeCAD
         version bump that fixes it is visible (this test starting to fail
         would mean the upstream bug is gone and this test should be
-        deleted, not "fixed")."""
+        deleted, not "fixed").
+
+        Already known upstream: https://github.com/FreeCAD/FreeCAD/issues/31849
+        (filed 2026-08-16, independently confirmed here 2026-08-21 against
+        weekly-2026.08.20 — same root cause, same trigger condition: >1
+        tool controller + no GUI to prompt a choice). Fix is up as
+        https://github.com/FreeCAD/FreeCAD/pull/31863 ("CAM: Fix
+        findToolController for console mode"), milestone 26.3, open as of
+        2026-08-21 — once merged into a build we test against, this test
+        should start failing and should be DELETED at that point, not
+        patched. The issue thread also documents a workaround for real
+        (non-test) usage: create operations while the job still has only
+        its single default tool controller, then add extra controllers
+        and reassign op.ToolController per-operation afterward — that
+        ordering never hits the multi-TC code path this bug lives in.
+        Separately, the same thread reports a more severe secondary bug
+        (a Proxy-less op left behind by the crash later hangs the whole
+        FreeCAD GUI on doc.removeObject() — not confirmed to affect
+        headless/MCP use, but worth knowing if any cleanup path ever
+        calls removeObject on a failed CAM operation object)."""
         send_command("cam_tools", {
             "operation": "create_tool", "name": "Second Tool",
             "tool_type": "endmill", "diameter": 8.0,

--- a/tests/integration/test_continue_selection.py
+++ b/tests/integration/test_continue_selection.py
@@ -1,0 +1,186 @@
+"""
+continue_selection integration tests — the interactive-selection resume
+dispatch (fillet/chamfer/draft/shell/thickness's request_selection ->
+GUI pick -> continue_selection round trip).
+
+This is the direct regression guard for a real bug found and fixed
+2026-08-20/21: freecad_mcp_handler.py's _continue_selection resume_methods
+dict mapped tool "thickness_faces" to a nonexistent
+self.partdesign_ops.thickness_faces (real method: add_thickness), so
+building that dict raised AttributeError unconditionally — breaking
+continue_selection for ALL FIVE interactive-selection tools (fillet,
+chamfer, draft, shell, thickness), not just thickness, for a month
+(since 2026-07-18) undetected. The only test that touched this dispatch
+was a unit test asserting against a MagicMock, which auto-vivifies any
+attribute name and can't catch a wrong method reference — see
+tests/unit/test_freecad_mcp_handler.py::TestContinueSelectionDispatch's
+strengthened version for that fix.
+
+This file exercises the REAL dispatch against a live FreeCAD process: seed
+server.selector.pending_operations exactly as request_selection would (via
+execute_python_sync reaching FreeCAD.__ai_socket_server.selector, the same
+handle headless_server.py and InitGui.py both expose), then call the
+actual continue_selection MCP tool.
+
+Architectural constraint confirmed live: UniversalSelector.complete_selection()
+checks `if not FreeCADGui: return {"error": "FreeCAD GUI not available for
+selection"}` BEFORE ever consulting pending_operations' content — headless
+FreeCAD has no FreeCADGui at all (not a flag to fake, the module doesn't
+exist), so no amount of pending_operations seeding can produce a real
+created object here. What this file CAN and does prove headless: dispatch
+reaches the CORRECT internal handler method for each of the five
+interactive-selection tools — the exact thing that broke — by asserting
+the clean, expected "FreeCAD GUI not available for selection" response
+rather than the crash-shaped "'PartDesignOpsHandler' object has no
+attribute ...' the original bug produced. A wrong resume_methods mapping
+would surface as that AttributeError text regardless of GUI availability;
+this file catches that class of bug even though it can't observe the
+GUI-mode success path. Real fillet/hole geometry creation (via fillet's
+public edges= bypass, which needs no GUI selection at all) is covered in
+test_partdesign_ops.py instead.
+"""
+
+import time
+import pytest
+from ._geom_helpers import _result_text as _text
+from .test_e2e_workflows import send_command
+
+
+@pytest.fixture
+def clean_document():
+    doc_name = f"ContSel_{int(time.time() * 1000) % 100000}"
+    send_command("view_control", {
+        "operation": "create_document",
+        "document_name": doc_name,
+    })
+    yield doc_name
+    try:
+        send_command("execute_python_sync", {
+            "code": f"FreeCAD.closeDocument('{doc_name}')"
+        })
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def body_with_pad(clean_document):
+    """A PartDesign Body with a padded 20x15x10 box, matching
+    test_partdesign_ops.py's fixture shape."""
+    send_command("execute_python_sync", {
+        "code": """
+import Part
+doc = FreeCAD.ActiveDocument
+body = doc.addObject('PartDesign::Body', 'Body')
+
+sketch = doc.addObject('Sketcher::SketchObject', 'PadSketch')
+body.addObject(sketch)
+sketch.AttachmentSupport = [(doc.getObject('XY_Plane'), '')]
+sketch.MapMode = 'FlatFace'
+
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(0,0,0), FreeCAD.Vector(20,0,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(20,0,0), FreeCAD.Vector(20,15,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(20,15,0), FreeCAD.Vector(0,15,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(0,15,0), FreeCAD.Vector(0,0,0)))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 1, 2, 2, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 2, 2, 3, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 3, 2, 0, 1))
+doc.recompute()
+
+pad = body.newObject('PartDesign::Pad', 'Pad')
+pad.Profile = sketch
+pad.Length = 10
+doc.recompute()
+"""
+    })
+    return clean_document
+
+
+def _seed_pending_selection(operation_id: str, tool: str, obj_name: str, elements: list, **extra):
+    """Seed server.selector.pending_operations exactly as
+    UniversalSelector.request_selection() would, and pre-load the FreeCAD
+    GUI selection state that complete_selection() reads from — bypassing
+    the actual request_selection() call (which we don't need to test
+    here; test_partdesign_ops.py already covers that half) so this file
+    can focus purely on continue_selection's dispatch correctness."""
+    extra_repr = ", ".join(f"{k!r}: {v!r}" for k, v in extra.items())
+    code = f"""
+import time
+server = FreeCAD.__ai_socket_server
+server.selector.pending_operations[{operation_id!r}] = {{
+    "tool": {tool!r}, "type": "edges", "object": {obj_name!r},
+    "timestamp": time.time(), {extra_repr}
+}}
+"""
+    result = send_command("execute_python_sync", {"code": code})
+    assert "error" not in _text(result).lower() or "Error" not in _text(result), _text(result)
+    return result
+
+
+class TestContinueSelectionFillet:
+    def test_resumes_to_the_real_fillet_method_headless(self, body_with_pad):
+        """The exact regression scenario: seed a pending fillet_edges
+        selection, then resume it via continue_selection. Dispatch must
+        reach PartDesignOpsHandler.fillet_edges (which then hits the
+        expected clean headless GUI-unavailable error) rather than crash
+        building the resume_methods lookup dict with an AttributeError
+        naming a wrong/nonexistent method."""
+        op_id = "fillet_edges_test_1"
+        _seed_pending_selection(op_id, "fillet_edges", "Pad", [1], radius=2.0, name="TestFillet")
+
+        result = send_command("continue_selection", {"operation_id": op_id})
+        text = _text(result)
+        assert "no attribute" not in text, f"dispatch attribute error — {text[:300]}"
+        assert "FreeCAD GUI not available for selection" in text, text[:300]
+
+    def test_unknown_operation_id_errors(self, body_with_pad):
+        result = send_command("continue_selection", {"operation_id": "does_not_exist"})
+        text = _text(result)
+        assert "not found" in text.lower() or "expired" in text.lower(), text[:300]
+
+    def test_missing_operation_id_errors(self, body_with_pad):
+        result = send_command("continue_selection", {})
+        text = _text(result)
+        assert "error" in text.lower() or "required" in text.lower(), text[:300]
+
+
+class TestContinueSelectionAllFiveTools:
+    """Every tool that calls selector.request_selection() must be
+    resumable through continue_selection. thickness_faces was the one
+    that broke (mapped to a nonexistent method); this loops over all
+    five so a future regression on any of them is caught the same way.
+
+    complete_selection() checks `if not FreeCADGui` before ever using
+    pending_operations' content (confirmed live — see module docstring),
+    so headless every tool's resume hits the same clean error regardless
+    of which one it is. That uniformity is itself the useful signal here:
+    dispatch reached the CORRECT tool-specific method (which then hit the
+    expected GUI guard) rather than crashing on a wrong/missing method
+    name before ever getting there."""
+
+    @pytest.mark.parametrize("tool,extra", [
+        ("fillet_edges", {"radius": 1.5, "name": "PFillet"}),
+        ("chamfer_edges", {"distance": 1.0, "name": "PChamfer"}),
+        ("draft_faces", {"angle": 5.0, "name": "PDraft"}),
+        ("shell_solid", {"thickness": 1.0, "name": "PShell"}),
+        ("thickness_faces", {"thickness": 1.0, "name": "PThickness"}),
+    ])
+    def test_each_tool_resumes_without_dispatch_error(self, body_with_pad, tool, extra):
+        op_id = f"{tool}_test_1"
+        elements = [1]
+        selection_type = "faces" if tool in ("draft_faces", "shell_solid", "thickness_faces") else "edges"
+        _seed_pending_selection(op_id, tool, "Pad", elements, **extra)
+        # Override the "edges" default _seed_pending_selection hardcodes,
+        # for the face-selecting tools.
+        send_command("execute_python_sync", {"code": f"""
+server = FreeCAD.__ai_socket_server
+server.selector.pending_operations[{op_id!r}]["type"] = {selection_type!r}
+"""})
+
+        result = send_command("continue_selection", {"operation_id": op_id})
+        text = _text(result)
+        # The regression this file exists to catch surfaces as exactly
+        # this AttributeError, regardless of which tool is resumed —
+        # assert its absence explicitly, not just "some success string".
+        assert "no attribute" not in text, f"{tool}: dispatch attribute error — {text[:300]}"
+        assert "FreeCAD GUI not available for selection" in text, f"{tool}: {text[:300]}"

--- a/tests/integration/test_e2e_workflows.py
+++ b/tests/integration/test_e2e_workflows.py
@@ -45,6 +45,15 @@ def _socket_call(tool: str, args: dict, timeout: float = 10.0) -> dict:
         resp_len = struct.unpack("!I", length_bytes)[0]
         resp_bytes = _recv_exact(s, resp_len)
         return json.loads(resp_bytes.decode("utf-8"))
+    except TimeoutError as e:
+        # A recv()/sendall() timeout means the process is either still
+        # alive but hung (nothing to diagnose from stdout/stderr — it
+        # hasn't exited) or has died in a way that didn't produce a clean
+        # EOF (_recv_exact's own "Socket closed" path handles the EOF
+        # case). Either way, surface whatever diagnose_dead_spawned_process
+        # can find rather than a bare "timed out" — if the process *did*
+        # die, this is the only place left to catch it for this call shape.
+        raise TimeoutError(f"{e}{conftest.diagnose_dead_spawned_process()}") from e
     finally:
         s.close()
 

--- a/tests/integration/test_execute_python_ops.py
+++ b/tests/integration/test_execute_python_ops.py
@@ -1,0 +1,108 @@
+"""
+Integration tests for execute_python_sync's Console-stderr capture
+(issue #49): FreeCAD's own C++ Console output (Console.PrintWarning,
+PrintError, PrintLog, PrintCritical, and warnings FreeCAD emits internally
+as a side effect of property sets/recomputes — e.g. deprecation notices)
+writes via raw fprintf(stderr, ...) at the C level, below Python's
+sys.stdout/sys.stderr, so run_code()'s io.StringIO() stdout capture never
+saw it. AICopilot/handlers/execute_python_ops.py now also redirects the
+real OS-level stderr fd for the duration of code execution and folds
+anything captured into the response under a "[FreeCAD Console]" heading.
+
+tests/unit/test_execute_python_ops.py's TestConsoleStderrCapture exercises
+the capture mechanism itself (raw os.write(2, ...), no real FreeCAD
+needed). This file instead confirms the actual real-world trigger this
+issue was filed over: FreeCAD's own C++ layer emitting a warning as a side
+effect of a property set, not a manual PrintWarning() call — the
+PartDesign::Pad Midplane deprecation notice from the original bug report.
+"""
+
+import json
+import time
+import pytest
+from ._geom_helpers import _result_text as _text
+from .test_e2e_workflows import send_command
+
+
+@pytest.fixture
+def clean_document():
+    doc_name = f"ExecPy_{int(time.time() * 1000) % 100000}"
+    send_command("view_control", {
+        "operation": "create_document",
+        "document_name": doc_name,
+    })
+    yield doc_name
+    try:
+        send_command("execute_python_sync", {
+            "code": f"FreeCAD.closeDocument('{doc_name}')"
+        })
+    except Exception:
+        pass
+
+
+class TestConsoleStderrCapture:
+    def test_manual_print_warning_surfaced(self, clean_document):
+        result = send_command("execute_python_sync", {
+            "code": "FreeCAD.Console.PrintWarning('manual test warning\\n')\nresult = 1 + 1",
+        })
+        text = _text(result)
+        assert "[FreeCAD Console]" in text, text
+        assert "manual test warning" in text, text
+        assert "2" in text, text
+
+    def test_no_warning_omits_console_section(self, clean_document):
+        result = send_command("execute_python_sync", {"code": "1 + 1"})
+        text = _text(result)
+        assert "[FreeCAD Console]" not in text, text
+
+    def test_pad_midplane_deprecation_warning_surfaced(self, clean_document):
+        """Exact reproduction of issue #49: FreeCAD's own C++ layer emits
+        a PrintWarning-level deprecation notice as a side effect of
+        setting PartDesign::Pad.Midplane, not from any explicit
+        PrintWarning() call in the executed code. Before this fix, this
+        was only visible via a separate, manual get_report_view call —
+        several tool calls after the fact in the original report."""
+        code = """
+import Part, Sketcher
+doc = FreeCAD.ActiveDocument
+body = doc.addObject('PartDesign::Body', 'Body')
+sketch = doc.addObject('Sketcher::SketchObject', 'Sk')
+body.addObject(sketch)
+sketch.AttachmentSupport = [(doc.getObject('XY_Plane'), '')]
+sketch.MapMode = 'FlatFace'
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(0,0,0), FreeCAD.Vector(10,0,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(10,0,0), FreeCAD.Vector(10,10,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(10,10,0), FreeCAD.Vector(0,10,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(0,10,0), FreeCAD.Vector(0,0,0)))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 1, 2, 2, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 2, 2, 3, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 3, 2, 0, 1))
+doc.recompute()
+pad = body.newObject('PartDesign::Pad', 'Pad')
+pad.Profile = sketch
+pad.Length = 10
+pad.Midplane = True
+doc.recompute()
+result = pad.Midplane
+"""
+        result = send_command("execute_python_sync", {"code": code}, timeout=20.0)
+        text = _text(result)
+        assert "[FreeCAD Console]" in text, text
+        assert "Midplane" in text and "deprecated" in text, text
+        assert "True" in text, text
+
+    def test_console_capture_does_not_break_subsequent_calls(self, clean_document):
+        """The OS-level fd redirect must be fully restored after each
+        call -- a leak here would corrupt every later call's stderr in
+        the same long-lived headless process, not just this handler's,
+        which is a much worse failure mode than a single wrong response."""
+        first = send_command("execute_python_sync", {
+            "code": "FreeCAD.Console.PrintWarning('first\\n')",
+        })
+        assert "first" in _text(first)
+        second = send_command("execute_python_sync", {"code": "2 + 2"})
+        text = _text(second)
+        assert "4" in text
+        assert "first" not in text, text
+        assert "[FreeCAD Console]" not in text, text

--- a/tests/integration/test_fixture_ops.py
+++ b/tests/integration/test_fixture_ops.py
@@ -1,0 +1,218 @@
+"""
+Fixture (snapshot regression) integration tests — save_fixture,
+compare_to_fixture.
+
+fixture_operations writes into the REAL repo fixtures/ directory (no
+test-injectable override — see AICopilot/handlers/fixture_ops.py's
+_fixtures_root(), which resolves two directories up from this file's own
+location on the FreeCAD-side process, i.e. the checked-in fixtures/ dir).
+Every fixture_name used here is uuid-suffixed and removed in a fixture
+teardown so tests never collide with or leave behind real fixtures like
+fixtures/shingle_complex_roof/.
+"""
+
+import json
+import os
+import shutil
+import time
+import uuid
+import pytest
+from ._geom_helpers import _result_text as _text
+from .test_e2e_workflows import send_command
+
+# fixtures/ lives at the repo root; this test file is at
+# tests/integration/test_fixture_ops.py — two directories up.
+_FIXTURES_ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "fixtures",
+)
+
+
+def _fixture_result(result) -> dict:
+    """Parse fixture_operations' {"ok": ..., "details": ..., "message": ...}
+    JSON envelope out of a send_command response."""
+    text = _text(result)
+    return json.loads(text)
+
+
+@pytest.fixture
+def clean_document():
+    doc_name = f"FixtureOps_{int(time.time() * 1000) % 100000}"
+    send_command("view_control", {
+        "operation": "create_document",
+        "document_name": doc_name,
+    })
+    yield doc_name
+    try:
+        send_command("execute_python_sync", {
+            "code": f"FreeCAD.closeDocument('{doc_name}')"
+        })
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def test_fixture_name():
+    """A collision-proof fixture_name, cleaned up from the real repo
+    fixtures/ directory in teardown regardless of what the test did to it."""
+    name = f"test-fixture-{uuid.uuid4().hex[:8]}"
+    yield name
+    shutil.rmtree(os.path.join(_FIXTURES_ROOT, name), ignore_errors=True)
+
+
+@pytest.fixture
+def known_box(clean_document):
+    send_command("part_operations", {
+        "operation": "box", "length": 20, "width": 15, "height": 10, "name": "FixtureBox",
+    })
+    return clean_document
+
+
+class TestSaveFixture:
+    def test_save_fixture_success(self, known_box, test_fixture_name):
+        result = send_command("fixture_operations", {
+            "operation": "save_fixture",
+            "shape": "FixtureBox",
+            "fixture_name": test_fixture_name,
+            "description": "integration test fixture",
+        })
+        parsed = _fixture_result(result)
+        assert parsed["ok"] is True, parsed
+        files = parsed["details"]["files_written"]
+        assert "topology.json" in files, files
+        assert "shape.stl" in files, files
+        assert "fixture.md" in files, files
+        # Headless: no GUI, no active view — screenshot must not be captured.
+        assert "screenshot.png" not in files, files
+        assert parsed["details"]["screenshot_captured"] is False, parsed["details"]
+
+        topo = parsed["details"]["topology"]
+        assert topo["face_count"] == 6
+        assert abs(topo["volume"] - 20 * 15 * 10) < 1e-6
+
+        fdir = os.path.join(_FIXTURES_ROOT, test_fixture_name)
+        assert os.path.isfile(os.path.join(fdir, "topology.json"))
+        assert os.path.isfile(os.path.join(fdir, "shape.stl"))
+        assert os.path.isfile(os.path.join(fdir, "fixture.md"))
+        assert not os.path.isfile(os.path.join(fdir, "screenshot.png"))
+
+    def test_save_fixture_missing_shape(self, clean_document, test_fixture_name):
+        result = send_command("fixture_operations", {
+            "operation": "save_fixture", "fixture_name": test_fixture_name,
+        })
+        parsed = _fixture_result(result)
+        assert parsed["ok"] is False
+        assert "shape" in parsed["message"].lower()
+
+    def test_save_fixture_rejects_unsafe_name(self, known_box):
+        result = send_command("fixture_operations", {
+            "operation": "save_fixture", "shape": "FixtureBox",
+            "fixture_name": "../evil",
+        })
+        parsed = _fixture_result(result)
+        assert parsed["ok"] is False
+        assert "invalid fixture_name" in parsed["message"].lower()
+        # Confirm nothing escaped fixtures/ — no directory literally named
+        # "evil" one level above the fixtures root.
+        escaped = os.path.join(os.path.dirname(_FIXTURES_ROOT), "evil")
+        assert not os.path.exists(escaped)
+
+
+class TestCompareToFixture:
+    def test_round_trip_matches(self, known_box, test_fixture_name):
+        save_result = send_command("fixture_operations", {
+            "operation": "save_fixture", "shape": "FixtureBox",
+            "fixture_name": test_fixture_name,
+        })
+        assert _fixture_result(save_result)["ok"] is True
+
+        compare_result = send_command("fixture_operations", {
+            "operation": "compare_to_fixture", "shape": "FixtureBox",
+            "fixture_name": test_fixture_name,
+        })
+        parsed = _fixture_result(compare_result)
+        assert parsed["ok"] is True, parsed
+        assert "matches fixture" in parsed["message"]
+
+    def test_resize_fails_volume_check(self, known_box, test_fixture_name):
+        send_command("fixture_operations", {
+            "operation": "save_fixture", "shape": "FixtureBox",
+            "fixture_name": test_fixture_name,
+        })
+        # Resize in place — same object name, new dimensions.
+        send_command("execute_python_sync", {"code": """
+doc = FreeCAD.ActiveDocument
+box = doc.getObject('FixtureBox')
+box.Length = 40
+doc.recompute()
+"""})
+        result = send_command("fixture_operations", {
+            "operation": "compare_to_fixture", "shape": "FixtureBox",
+            "fixture_name": test_fixture_name,
+        })
+        parsed = _fixture_result(result)
+        assert parsed["ok"] is False, parsed
+        assert parsed["details"]["checks"]["volume"]["ok"] is False
+        assert "volume" in parsed["message"].lower()
+
+    def test_pure_translation_fails_only_center_of_mass(self, known_box, test_fixture_name):
+        """A pure translation leaves face/edge/vertex counts, volume, and
+        bbox EXTENT unchanged, but shifts center_of_mass — the exact field
+        schema v2 added specifically to catch a mirror/chirality flip
+        (see fixture_ops.py's _SCHEMA_VERSION comment). bbox itself still
+        shifts (it's absolute min/max, not extent), so both bbox and
+        center_of_mass are expected to fail here; volume and topology
+        counts must still pass."""
+        send_command("fixture_operations", {
+            "operation": "save_fixture", "shape": "FixtureBox",
+            "fixture_name": test_fixture_name,
+        })
+        send_command("execute_python_sync", {"code": """
+import FreeCAD
+doc = FreeCAD.ActiveDocument
+box = doc.getObject('FixtureBox')
+box.Placement.Base = FreeCAD.Vector(100, 0, 0)
+doc.recompute()
+"""})
+        result = send_command("fixture_operations", {
+            "operation": "compare_to_fixture", "shape": "FixtureBox",
+            "fixture_name": test_fixture_name,
+        })
+        parsed = _fixture_result(result)
+        assert parsed["ok"] is False, parsed
+        checks = parsed["details"]["checks"]
+        assert checks["center_of_mass"]["ok"] is False, checks
+        assert checks["volume"]["ok"] is True, checks
+        for field in ("face_count", "edge_count", "vertex_count", "solids_count", "shells_count"):
+            assert checks[field]["ok"] is True, (field, checks[field])
+
+    def test_missing_fixture(self, known_box):
+        result = send_command("fixture_operations", {
+            "operation": "compare_to_fixture", "shape": "FixtureBox",
+            "fixture_name": "does-not-exist-fixture",
+        })
+        parsed = _fixture_result(result)
+        assert parsed["ok"] is False
+        assert "not found" in parsed["message"].lower()
+
+    def test_schema_version_mismatch(self, known_box, test_fixture_name):
+        fdir = os.path.join(_FIXTURES_ROOT, test_fixture_name)
+        os.makedirs(fdir, exist_ok=True)
+        with open(os.path.join(fdir, "topology.json"), "w") as f:
+            json.dump({"schema_version": 1, "face_count": 6}, f)
+
+        result = send_command("fixture_operations", {
+            "operation": "compare_to_fixture", "shape": "FixtureBox",
+            "fixture_name": test_fixture_name,
+        })
+        parsed = _fixture_result(result)
+        assert parsed["ok"] is False
+        assert "schema version mismatch" in parsed["message"].lower()
+
+    def test_compare_missing_shape_arg(self, clean_document, test_fixture_name):
+        result = send_command("fixture_operations", {
+            "operation": "compare_to_fixture", "fixture_name": test_fixture_name,
+        })
+        parsed = _fixture_result(result)
+        assert parsed["ok"] is False
+        assert "shape" in parsed["message"].lower()

--- a/tests/integration/test_misc_ops.py
+++ b/tests/integration/test_misc_ops.py
@@ -20,6 +20,16 @@ test in this suite already uses via send_command's helper) before ever
 reaching the FreeCAD-side handler this tier talks to. Testing the
 MCP-facing translation belongs at the MCP-protocol test layer
 (tests/unit/test_mcp_protocol.py), not here.
+
+run_inspector and build_sketch both import from the FC-tools sibling repo
+(hardcoded fallback path /Volumes/Files/claude/FC-tools; see
+AICopilot/handlers/inspector_ops.py and sketch_builder_ops.py) rather than
+anything inside this repo. That repo exists on the dev machine but is not
+checked out in CI, so any test that exercises the real (FC-tools-backed)
+behavior of these two tools is marked `@pytest.mark.fc_tools` and excluded
+from the CI run (see .github/workflows/integration-tests.yml's pytest_args).
+Only build_sketch's pure-validation error path (layout not a dict, checked
+before FC-tools is ever imported) is CI-safe and left unmarked.
 """
 
 import json
@@ -210,6 +220,7 @@ class TestVerifyTopology:
 
 
 class TestRunInspector:
+    @pytest.mark.fc_tools
     def test_model_only_check_on_valid_box(self, clean_document):
         send_command("part_operations", {
             "operation": "box", "length": 10, "width": 10, "height": 10, "name": "InspBox",
@@ -224,6 +235,7 @@ class TestRunInspector:
 
 
 class TestBuildSketch:
+    @pytest.mark.fc_tools
     def test_empty_layout_with_spreadsheet(self, clean_document):
         send_command("execute_python_sync", {"code": """
 FreeCAD.ActiveDocument.addObject('Spreadsheet::Sheet', 'Spreadsheet')
@@ -234,6 +246,7 @@ FreeCAD.ActiveDocument.recompute()
         assert parsed["ok"] is True, parsed
         assert parsed["geo"] == 0
 
+    @pytest.mark.fc_tools
     def test_missing_spreadsheet_errors(self, clean_document):
         result = send_command("build_sketch", {"layout": {"elements": []}})
         parsed = _parsed(result)

--- a/tests/integration/test_misc_ops.py
+++ b/tests/integration/test_misc_ops.py
@@ -1,0 +1,302 @@
+"""
+Integration tests for the remaining "API-shaped" MCP tools that had zero
+integration-tier coverage and aren't GUI-blocked: geometric_verification,
+run_inspector, build_sketch, get_debug_logs, get_last_traceback,
+list_jobs, cancel_operation.
+
+cancel_job is NOT covered here — exercising its real success path needs a
+genuinely long-running async job to cancel mid-flight, which is a
+different (much slower/flakier) kind of test than everything else in this
+file; its error paths (unknown job_id, job not running) are simple
+argument validation already covered by the same pattern as every other
+handler's required-arg checks elsewhere in this suite, so a dedicated
+file for it wasn't judged worth the added run time here.
+
+execute_python / execute_python_async are NOT reachable via this
+integration tier's direct-socket test harness at all — they're MCP
+tool names implemented entirely on the bridge side (freecad_mcp_server.py),
+translated to execute_python_sync (the actual socket-level command every
+test in this suite already uses via send_command's helper) before ever
+reaching the FreeCAD-side handler this tier talks to. Testing the
+MCP-facing translation belongs at the MCP-protocol test layer
+(tests/unit/test_mcp_protocol.py), not here.
+"""
+
+import json
+import time
+import pytest
+from ._geom_helpers import _result_text as _text
+from .test_e2e_workflows import send_command
+
+
+@pytest.fixture
+def clean_document():
+    doc_name = f"MiscOps_{int(time.time() * 1000) % 100000}"
+    send_command("view_control", {
+        "operation": "create_document",
+        "document_name": doc_name,
+    })
+    yield doc_name
+    try:
+        send_command("execute_python_sync", {
+            "code": f"FreeCAD.closeDocument('{doc_name}')"
+        })
+    except Exception:
+        pass
+
+
+def _parsed(result) -> dict:
+    return json.loads(_text(result))
+
+
+class TestVerifyHandedness:
+    """Pure math — no FreeCAD document/object needed at all."""
+
+    def test_identity_matrix_is_right_handed(self, clean_document):
+        result = send_command("geometric_verification", {
+            "operation": "verify_handedness",
+            "matrix": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is True
+        assert abs(parsed["details"]["determinant"] - 1.0) < 1e-9
+
+    def test_left_handed_matrix_rejected(self, clean_document):
+        """Swapping two rows/columns flips the determinant to -1 — the
+        exact mirror-reflection bug this tool exists to catch."""
+        result = send_command("geometric_verification", {
+            "operation": "verify_handedness",
+            "matrix": [[1, 0, 0], [0, 0, 1], [0, 1, 0]],
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is False
+        assert abs(parsed["details"]["determinant"] - (-1.0)) < 1e-9
+        assert "left-handed" in parsed["message"].lower()
+
+    def test_missing_matrix_arg(self, clean_document):
+        result = send_command("geometric_verification", {"operation": "verify_handedness"})
+        parsed = _parsed(result)
+        assert parsed["ok"] is False
+        assert "matrix" in parsed["message"].lower()
+
+
+class TestVerifyOrientation:
+    @pytest.fixture
+    def rect_box(self, clean_document):
+        """A non-cube box — a cube's 6 equal-area faces make "dominant
+        face" (largest area) ambiguous/coin-flip; 20x15x10 has an
+        unambiguous largest-area pair (the 20x15 top/bottom)."""
+        send_command("part_operations", {
+            "operation": "box", "length": 20, "width": 15, "height": 10, "name": "OrientBox",
+        })
+        return clean_document
+
+    def test_dominant_face_matches_expected_axis(self, rect_box):
+        """A box's top and bottom faces always TIE in area (they're
+        congruent) — 'dominant' picks whichever is found first by
+        `area > dominant_area` (strict, not >=), so a tie never displaces
+        the first match. Confirmed live: for a part_operations box, the
+        bottom face (-Z, Face5 in this codebase's established face
+        numbering) iterates before the top (+Z, Face6) and wins every
+        tie, regardless of box proportions. So '-Z' is the axis that
+        actually matches the real dominant face here, not '+Z' — pinning
+        this order-dependent tie-break as real behavior, not asserting
+        the more intuitive-but-wrong "+Z is up" expectation."""
+        result = send_command("geometric_verification", {
+            "operation": "verify_orientation", "object_name": "OrientBox",
+            "expected_axis": "-Z", "mode": "dominant",
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is True, parsed
+        assert parsed["details"]["dominant_dot"] > 0
+
+    def test_dominant_face_opposite_axis_fails(self, rect_box):
+        result = send_command("geometric_verification", {
+            "operation": "verify_orientation", "object_name": "OrientBox",
+            "expected_axis": "+Z", "mode": "dominant",
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is False, parsed
+        assert "FAIL" in parsed["message"]
+
+    def test_all_mode_requires_every_face_aligned(self, rect_box):
+        """No axis makes ALL 6 faces of a box point the same way — this
+        pins that 'all' mode correctly fails for any real box."""
+        result = send_command("geometric_verification", {
+            "operation": "verify_orientation", "object_name": "OrientBox",
+            "expected_axis": "+Z", "mode": "all",
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is False, parsed
+
+    def test_unknown_mode_errors(self, rect_box):
+        result = send_command("geometric_verification", {
+            "operation": "verify_orientation", "object_name": "OrientBox",
+            "expected_axis": "+Z", "mode": "bogus",
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is False
+        assert "unknown mode" in parsed["message"].lower()
+
+    def test_missing_object(self, clean_document):
+        result = send_command("geometric_verification", {
+            "operation": "verify_orientation", "object_name": "Ghost", "expected_axis": "+Z",
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is False
+
+
+class TestVerifyNoSelfIntersection:
+    def test_valid_box_passes(self, clean_document):
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "GoodBox",
+        })
+        result = send_command("geometric_verification", {
+            "operation": "verify_no_self_intersection", "object_name": "GoodBox",
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is True, parsed
+        assert parsed["details"]["is_valid"] is True
+        assert parsed["details"]["solid_count"] == 1
+
+    def test_missing_object_name(self, clean_document):
+        result = send_command("geometric_verification", {
+            "operation": "verify_no_self_intersection",
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is False
+        assert "object_name" in parsed["message"].lower()
+
+
+class TestVerifyTopology:
+    def test_all_constraints_pass(self, clean_document):
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "TopoBox",
+        })
+        result = send_command("geometric_verification", {
+            "operation": "verify_topology", "object_name": "TopoBox",
+            "face_count": 6, "edge_count": 12, "vertex_count": 8,
+            "volume_range": [900, 1100],
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is True, parsed
+        assert len(parsed["details"]["checks"]) == 4
+        assert all(c["pass"] for c in parsed["details"]["checks"].values())
+
+    def test_wrong_face_count_fails(self, clean_document):
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "TopoBox2",
+        })
+        result = send_command("geometric_verification", {
+            "operation": "verify_topology", "object_name": "TopoBox2", "face_count": 999,
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is False, parsed
+        assert parsed["details"]["checks"]["face_count"]["pass"] is False
+        assert parsed["details"]["checks"]["face_count"]["actual"] == 6
+
+    def test_no_constraints_given_trivially_passes(self, clean_document):
+        """All check params are optional — omitting every one means
+        nothing was checked, which is vacuously 'ok' (no failures)."""
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "TopoBox3",
+        })
+        result = send_command("geometric_verification", {
+            "operation": "verify_topology", "object_name": "TopoBox3",
+        })
+        parsed = _parsed(result)
+        assert parsed["ok"] is True, parsed
+        assert parsed["details"]["checks"] == {}
+
+
+class TestRunInspector:
+    def test_model_only_check_on_valid_box(self, clean_document):
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "InspBox",
+        })
+        result = send_command("run_inspector", {})
+        text = _text(result)
+        parsed = json.loads(text)
+        assert parsed["object_count"] >= 1
+        assert "InspBox" in parsed["checked_objects"]
+        assert parsed["profile"] == "model-only"
+        assert parsed["summary"]["error"] == 0
+
+
+class TestBuildSketch:
+    def test_empty_layout_with_spreadsheet(self, clean_document):
+        send_command("execute_python_sync", {"code": """
+FreeCAD.ActiveDocument.addObject('Spreadsheet::Sheet', 'Spreadsheet')
+FreeCAD.ActiveDocument.recompute()
+"""})
+        result = send_command("build_sketch", {"layout": {"elements": []}})
+        parsed = _parsed(result)
+        assert parsed["ok"] is True, parsed
+        assert parsed["geo"] == 0
+
+    def test_missing_spreadsheet_errors(self, clean_document):
+        result = send_command("build_sketch", {"layout": {"elements": []}})
+        parsed = _parsed(result)
+        assert parsed["ok"] is False
+        assert "spreadsheet" in parsed["error"].lower()
+        assert "not found" in parsed["error"].lower()
+
+    def test_layout_not_a_dict_errors(self, clean_document):
+        result = send_command("build_sketch", {"layout": "not-a-dict"})
+        parsed = _parsed(result)
+        assert parsed["ok"] is False
+        assert "layout must be a dict" in parsed["error"]
+
+
+class TestJobIntrospection:
+    def test_list_jobs_empty(self, clean_document):
+        result = send_command("list_jobs", {})
+        parsed = _text(result)
+        parsed_json = json.loads(parsed) if isinstance(parsed, str) else result
+        assert parsed_json.get("count", None) is not None
+        # Best-effort: don't assert count == 0, other concurrent test runs
+        # against the same spawned instance could leave stale entries —
+        # just confirm the shape is right.
+        assert "jobs" in parsed_json
+
+    def test_cancel_operation_headless(self, clean_document):
+        """Headless has no FreeCADGui.cancelOperation to call — confirms
+        this returns a clean error, not a crash that takes the socket
+        down."""
+        result = send_command("cancel_operation", {})
+        text = _text(result)
+        assert "cancelOperation" in text or "error" in text.lower(), text[:300]
+
+
+class TestDebugLogs:
+    def test_get_debug_logs_no_logs(self, clean_document):
+        result = send_command("get_debug_logs", {})
+        text = _text(result)
+        assert "no" in text.lower() and (
+            "debug logs" in text.lower() or "log files" in text.lower()
+        ), text[:300]
+
+    def test_get_last_traceback_default_shape(self, clean_document):
+        """The ring buffer is server-instance-scoped, not per-test — other
+        test files in the same session-shared FreeCAD instance may have
+        already triggered errors that landed in it before this test runs,
+        so this only asserts the response shape, not an empty buffer
+        (confirmed live: asserting empty here is order-dependent and
+        flaky against the full suite, not just this file alone)."""
+        result = send_command("get_last_traceback", {})
+        parsed = _parsed(result)
+        assert "tracebacks" in parsed
+        assert "total_stored" in parsed
+        assert isinstance(parsed["tracebacks"], list)
+        # count defaults to 1 — tracebacks is capped there even if more exist.
+        assert parsed["total_stored"] >= len(parsed["tracebacks"])
+
+    def test_get_last_traceback_after_real_error(self, clean_document):
+        """Trigger a genuine Python exception via execute_python_sync,
+        then confirm it shows up in the ring buffer."""
+        send_command("execute_python_sync", {"code": "raise ValueError('deliberate test error')"})
+        result = send_command("get_last_traceback", {"count": 1})
+        parsed = _parsed(result)
+        assert parsed["total_stored"] >= 1
+        assert len(parsed["tracebacks"]) >= 1
+        assert "deliberate test error" in json.dumps(parsed["tracebacks"][-1])

--- a/tests/integration/test_partdesign_ops.py
+++ b/tests/integration/test_partdesign_ops.py
@@ -645,25 +645,36 @@ class TestHoleWizard:
         assert "countersink hole" in text.lower(), text[:300]
         assert "PartDesign::Hole" in text, text[:300]
 
-    def test_operation_name_alone_does_not_select_hole_type(self, body_with_pad):
-        """Pins a real, current dispatch quirk: `operation="counterbore"`
-        and `operation="countersink"` both route to the same hole_wizard
-        method as `operation="hole"` (freecad_mcp_handler.py's
-        operation_map has no auto-injection of hole_type from the
-        operation name) -- hole_wizard reads hole_type from its OWN args,
-        defaulting to 'simple' regardless of which of the three
-        operations dispatched here. Calling operation="counterbore"
-        WITHOUT an explicit hole_type therefore silently creates a
-        SIMPLE hole, not a counterbore. This is current, real behavior
-        being pinned, not necessarily desired behavior -- flagged
-        separately, not fixed here."""
+    def test_operation_name_alone_selects_hole_type(self, body_with_pad):
+        """`operation="counterbore"`/`"countersink"` and `operation="hole"`
+        all route to the same hole_wizard method (freecad_mcp_handler.py's
+        operation_map) -- hole_wizard used to read hole_type only from its
+        own args, defaulting to 'simple' regardless of which of the three
+        operations dispatched here, so operation="counterbore" WITHOUT an
+        explicit hole_type used to silently create a plain hole (confirmed
+        live, fixed 2026-08-21). args['operation'] is the original
+        dispatched name, still present in the same args dict hole_wizard
+        receives -- now used to infer hole_type when the caller doesn't
+        pass it explicitly."""
         result = send_command("partdesign_operations", {
             "operation": "counterbore", "object_name": "Pad",
             "diameter": 5, "depth": 5, "x": 0, "y": 0, "face_index": 6,
         })
         text = _text(result)
-        assert "simple hole" in text.lower(), text[:300]
-        assert "counterbore" not in text.lower(), text[:300]
+        assert "counterbore hole" in text.lower(), text[:300]
+
+    def test_explicit_hole_type_still_overrides_operation_name(self, body_with_pad):
+        """Explicit hole_type is authoritative over the inferred-from-
+        operation-name default -- operation="hole" with an explicit
+        hole_type="countersink" still creates a countersink, not a plain
+        hole."""
+        result = send_command("partdesign_operations", {
+            "operation": "hole", "object_name": "Pad", "hole_type": "countersink",
+            "diameter": 5, "depth": 5, "cb_diameter": 9, "cb_depth": 2,
+            "x": 0, "y": 0, "face_index": 6,
+        })
+        text = _text(result)
+        assert "countersink hole" in text.lower(), text[:300]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_partdesign_ops.py
+++ b/tests/integration/test_partdesign_ops.py
@@ -535,6 +535,245 @@ class TestPatterns:
 
 
 # ---------------------------------------------------------------------------
+# Tests: Fillet via the public edges= bypass (no GUI selection needed)
+# ---------------------------------------------------------------------------
+
+class TestFilletExplicitEdges:
+    def test_fillet_specific_edges_real_geometry(self, body_with_pad):
+        """fillet's `edges` param (a list of 1-based edge indices) routes
+        straight to _create_fillet_with_edges — no GUI selection handshake
+        at all, so this is real, non-error-path headless coverage of the
+        actual PartDesign::Fillet creation logic."""
+        doc_name = body_with_pad
+        result = send_command("partdesign_operations", {
+            "operation": "fillet", "object_name": "Pad",
+            "edges": [1], "radius": 2.0, "name": "ExplicitFillet",
+        })
+        assert_op_succeeded(result, "fillet(edges=[1])")
+        text = _text(result)
+        assert "Created fillet" in text, text[:300]
+
+        props = get_shape_props(doc_name, "ExplicitFillet")
+        assert props is not None
+        assert props["is_valid"]
+        # A fillet removes material — strictly less than the unfilleted
+        # pad's 20*15*10 = 3000 mm^3, but still close (small radius).
+        assert props["volume"] < 3000.0
+        assert_volume_close(props["volume"], 3000.0, rel=0.05, op_label="filleted pad volume")
+
+    def test_fillet_out_of_range_edge_index_fails_loudly_not_silently(self, body_with_pad):
+        """_create_fillet_with_edges's bounds-check (1 <= idx <=
+        len(Shape.Edges)) only applies to the non-Body Part::Fillet
+        fallback branch — a Body-based PartDesign::Fillet (this fixture's
+        case) builds Edge{idx} names for every given index unconditionally,
+        with no bounds-check at all. An out-of-range index therefore isn't
+        silently dropped here (unlike the non-Body path); it reaches OCCT
+        as a real invalid edge reference, and _check_feature_state catches
+        the resulting State=Invalid and reports it — a loud, reported
+        failure, not silent data loss or a crash. Pinning this asymmetry
+        as real current behavior, not fixing it here."""
+        result = send_command("partdesign_operations", {
+            "operation": "fillet", "object_name": "Pad",
+            "edges": [1, 9999], "radius": 1.0, "name": "PartialFillet",
+        })
+        text = _text(result)
+        assert "failed to compute" in text and "Invalid" in text, text[:300]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Hole wizard (hole / counterbore / countersink)
+# ---------------------------------------------------------------------------
+
+class TestHoleWizard:
+    def test_standalone_simple_hole_no_body(self, clean_document):
+        """No face_index, no Body -- the original CSG cylinder-cut path."""
+        doc_name = clean_document
+        send_command("part_operations", {
+            "operation": "box", "length": 20, "width": 20, "height": 10, "name": "HoleBox",
+        })
+        result = send_command("partdesign_operations", {
+            "operation": "hole", "object_name": "HoleBox", "hole_type": "simple",
+            "diameter": 6, "depth": 10, "x": 10, "y": 10,
+        })
+        text = _text(result)
+        assert "hole" in text.lower(), text[:300]
+        assert "Error" not in text.split("\n")[0], text[:300]
+
+        props = get_shape_props(doc_name, "HoleBox_WithHole")
+        assert props is not None, text
+        assert props["is_valid"]
+        # A through-hole strictly reduces volume below the box's 20*20*10=4000.
+        assert props["volume"] < 4000.0
+
+    def test_body_aware_simple_hole_on_top_face(self, body_with_pad):
+        """face_index given + object in a Body -> genuine PartDesign::Hole.
+        Pad's top face (Face6, z=10 plane per test_e2e_workflows'
+        established face numbering for this exact box shape) is used so
+        x=0,y=0 lands at the face's own centroid (hole_wizard recenters
+        local (0,0) to the face's CenterOfMass, not the native FlatFace
+        origin)."""
+        doc_name = body_with_pad
+        result = send_command("partdesign_operations", {
+            "operation": "hole", "object_name": "Pad", "hole_type": "simple",
+            "diameter": 5, "depth": 5, "x": 0, "y": 0, "face_index": 6,
+        })
+        text = _text(result)
+        assert "PartDesign::Hole" in text, text[:300]
+        assert "Face6" in text, text[:300]
+
+        props = get_shape_props(doc_name, "Pad_Hole")
+        assert props is not None, text
+        assert props["is_valid"]
+
+    def test_body_aware_counterbore(self, body_with_pad):
+        result = send_command("partdesign_operations", {
+            "operation": "counterbore", "object_name": "Pad", "hole_type": "counterbore",
+            "diameter": 5, "depth": 5, "cb_diameter": 9, "cb_depth": 2,
+            "x": 0, "y": 0, "face_index": 6,
+        })
+        text = _text(result)
+        assert "counterbore hole" in text.lower(), text[:300]
+        assert "PartDesign::Hole" in text, text[:300]
+
+    def test_body_aware_countersink(self, body_with_pad):
+        result = send_command("partdesign_operations", {
+            "operation": "countersink", "object_name": "Pad", "hole_type": "countersink",
+            "diameter": 5, "depth": 5, "cb_diameter": 9, "cb_depth": 2,
+            "x": 0, "y": 0, "face_index": 6,
+        })
+        text = _text(result)
+        assert "countersink hole" in text.lower(), text[:300]
+        assert "PartDesign::Hole" in text, text[:300]
+
+    def test_operation_name_alone_does_not_select_hole_type(self, body_with_pad):
+        """Pins a real, current dispatch quirk: `operation="counterbore"`
+        and `operation="countersink"` both route to the same hole_wizard
+        method as `operation="hole"` (freecad_mcp_handler.py's
+        operation_map has no auto-injection of hole_type from the
+        operation name) -- hole_wizard reads hole_type from its OWN args,
+        defaulting to 'simple' regardless of which of the three
+        operations dispatched here. Calling operation="counterbore"
+        WITHOUT an explicit hole_type therefore silently creates a
+        SIMPLE hole, not a counterbore. This is current, real behavior
+        being pinned, not necessarily desired behavior -- flagged
+        separately, not fixed here."""
+        result = send_command("partdesign_operations", {
+            "operation": "counterbore", "object_name": "Pad",
+            "diameter": 5, "depth": 5, "x": 0, "y": 0, "face_index": 6,
+        })
+        text = _text(result)
+        assert "simple hole" in text.lower(), text[:300]
+        assert "counterbore" not in text.lower(), text[:300]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Chamfer / Draft real geometry via internal-method reach-in
+# (Phase 2 — see the plan's note: this exercises the real creation/
+# recompute logic but bypasses the public continue_selection dispatch,
+# a narrower guard than test_continue_selection.py's dispatch-level tests.
+# Reached via FreeCAD.__ai_socket_server.partdesign_ops, the same handle
+# headless_server.py/InitGui.py expose for the running FreeCADSocketServer
+# instance.)
+# ---------------------------------------------------------------------------
+
+def _call_internal_selection_method(method_name: str, args: dict, elements: list) -> str:
+    code = f"""
+server = FreeCAD.__ai_socket_server
+selection_result = {{"selection_data": {{"elements": {elements!r}}}}}
+print(server.partdesign_ops.{method_name}({args!r}, selection_result))
+result = None
+"""
+    raw = send_command("execute_python_sync", {"code": code})
+    text = _text(raw)
+    if text.startswith("Result: "):
+        text = text[len("Result: "):]
+    return text.strip()
+
+
+class TestChamferRealGeometry:
+    def test_chamfer_specific_edges(self, body_with_pad):
+        doc_name = body_with_pad
+        text = _call_internal_selection_method(
+            "_create_chamfer_with_selection",
+            {"object_name": "Pad", "distance": 1.5, "name": "RealChamfer"},
+            [1],
+        )
+        assert "Created chamfer" in text, text[:300]
+
+        props = get_shape_props(doc_name, "RealChamfer")
+        assert props is not None
+        assert props["is_valid"]
+        assert props["volume"] < 3000.0
+        assert_volume_close(props["volume"], 3000.0, rel=0.05, op_label="chamfered pad volume")
+
+
+class TestDraftRealGeometry:
+    def test_draft_specific_face(self, body_with_pad):
+        doc_name = body_with_pad
+        text = _call_internal_selection_method(
+            "_create_draft_with_selection",
+            {"object_name": "Pad", "angle": 3.0, "name": "RealDraft"},
+            [1],
+        )
+        assert "Created draft" in text, text[:300]
+
+        props = get_shape_props(doc_name, "RealDraft")
+        assert props is not None
+        assert props["is_valid"]
+
+    def test_draft_requires_body(self, clean_document):
+        """_create_draft_with_selection explicitly rejects a non-Body
+        target rather than crashing on a missing find_body_for_object
+        result."""
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "BareBox",
+        })
+        text = _call_internal_selection_method(
+            "_create_draft_with_selection",
+            {"object_name": "BareBox", "angle": 3.0, "name": "ShouldFail"},
+            [1],
+        )
+        assert "requires object to be in a PartDesign Body" in text, text[:300]
+
+
+class TestShellThicknessRealGeometry:
+    """Upgrades the existing TestShellThickness dispatch-only tests (which
+    only assert the dispatch doesn't dead-letter) with real hollow-geometry
+    assertions, using the same internal-method reach-in as chamfer/draft
+    above."""
+
+    def test_shell_specific_face_real_hollow_volume(self, body_with_pad):
+        doc_name = body_with_pad
+        text = _call_internal_selection_method(
+            "_create_shell_with_selection",
+            {"object_name": "Pad", "thickness": 2.0, "name": "RealShell"},
+            [6],
+        )
+        assert "Created shell" in text, text[:300]
+
+        props = get_shape_props(doc_name, "RealShell")
+        assert props is not None
+        assert props["is_valid"]
+        # Hollowed 20x15x10 box, 2mm walls, one face open: strictly less
+        # than the solid 3000 mm^3, strictly more than 0.
+        assert 0 < props["volume"] < 3000.0
+
+    def test_thickness_specific_face_real_hollow_volume(self, body_with_pad):
+        doc_name = body_with_pad
+        text = _call_internal_selection_method(
+            "_create_thickness_with_selection",
+            {"object_name": "Pad", "thickness": 2.0, "name": "RealThickness"},
+            [6],
+        )
+        assert "Created PartDesign Thickness" in text, text[:300]
+
+        props = get_shape_props(doc_name, "RealThickness")
+        assert props is not None
+        assert props["is_valid"]
+        assert 0 < props["volume"] < 3000.0
+
+
+# ---------------------------------------------------------------------------
 # Tests: Unknown operation
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_partdesign_ops.py
+++ b/tests/integration/test_partdesign_ops.py
@@ -561,23 +561,72 @@ class TestFilletExplicitEdges:
         assert props["volume"] < 3000.0
         assert_volume_close(props["volume"], 3000.0, rel=0.05, op_label="filleted pad volume")
 
-    def test_fillet_out_of_range_edge_index_fails_loudly_not_silently(self, body_with_pad):
-        """_create_fillet_with_edges's bounds-check (1 <= idx <=
-        len(Shape.Edges)) only applies to the non-Body Part::Fillet
-        fallback branch — a Body-based PartDesign::Fillet (this fixture's
-        case) builds Edge{idx} names for every given index unconditionally,
-        with no bounds-check at all. An out-of-range index therefore isn't
-        silently dropped here (unlike the non-Body path); it reaches OCCT
-        as a real invalid edge reference, and _check_feature_state catches
-        the resulting State=Invalid and reports it — a loud, reported
-        failure, not silent data loss or a crash. Pinning this asymmetry
-        as real current behavior, not fixing it here."""
+    def test_fillet_out_of_range_edge_index_fails_loudly_not_silently_body_path(self, body_with_pad):
+        """The Body-based PartDesign::Fillet path builds Edge{idx} names
+        for every given index unconditionally, with no upfront
+        bounds-check — an out-of-range index reaches OCCT as a real
+        invalid edge reference, and _check_feature_state catches the
+        resulting State=Invalid and reports it: a loud, reported failure,
+        not silent data loss or a crash. (The non-Body Part::Fillet
+        fallback used to silently drop out-of-range indices instead of
+        erroring — fixed 2026-08-21, see TestFilletExplicitEdgesNoBody
+        below — so both paths now fail loud on bad input, just via
+        different mechanisms: OCCT recompute failure here vs. explicit
+        upfront rejection there.)"""
         result = send_command("partdesign_operations", {
             "operation": "fillet", "object_name": "Pad",
             "edges": [1, 9999], "radius": 1.0, "name": "PartialFillet",
         })
         text = _text(result)
         assert "failed to compute" in text and "Invalid" in text, text[:300]
+
+
+class TestFilletExplicitEdgesNoBody:
+    """The non-Body Part::Fillet fallback (object not in a PartDesign
+    Body) used to silently filter out any out-of-range edge index and
+    create a fillet on fewer edges than requested, with no indication any
+    were skipped. Fixed 2026-08-21 to validate all indices up front and
+    reject explicitly instead — matching the Body path's own fail-loud
+    behavior (TestFilletExplicitEdges.test_fillet_out_of_range_edge_index_fails_loudly_not_silently_body_path)."""
+
+    def test_out_of_range_index_rejected_before_creating_anything(self, clean_document):
+        doc_name = clean_document
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "BareBox",
+        })
+        result = send_command("partdesign_operations", {
+            "operation": "fillet", "object_name": "BareBox",
+            "edges": [1, 99], "radius": 1.0,
+        })
+        text = _text(result)
+        assert "Invalid edge index" in text and "99" in text, text[:300]
+        assert "valid range 1-12" in text, text[:300]
+
+        check = send_command("execute_python_sync", {
+            "code": f"print(FreeCAD.getDocument({doc_name!r}).getObject('Fillet') is None)"
+        })
+        assert _text(check).strip().endswith("True"), (
+            "Expected no Fillet object to have been created at all — "
+            f"got: {_text(check)[:300]}"
+        )
+
+    def test_all_valid_indices_still_succeed(self, clean_document):
+        doc_name = clean_document
+        send_command("part_operations", {
+            "operation": "box", "length": 10, "width": 10, "height": 10, "name": "BareBox2",
+        })
+        result = send_command("partdesign_operations", {
+            "operation": "fillet", "object_name": "BareBox2",
+            "edges": [1, 2], "radius": 1.0,
+        })
+        assert_op_succeeded(result, "fillet(no Body, valid edges)")
+        text = _text(result)
+        assert "Created fillet" in text and "2 edges" in text, text[:300]
+
+        props = get_shape_props(doc_name, "Fillet")
+        assert props is not None
+        assert props["is_valid"]
+        assert props["volume"] < 1000.0  # 10^3, unfilleted
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_partdesign_ops.py
+++ b/tests/integration/test_partdesign_ops.py
@@ -774,6 +774,425 @@ class TestShellThicknessRealGeometry:
 
 
 # ---------------------------------------------------------------------------
+# Tests: Groove (subtractive revolution — needs an existing base feature
+# to cut into, unlike revolution)
+# ---------------------------------------------------------------------------
+
+class TestGroove:
+    def test_groove_cuts_ring_channel(self, clean_document):
+        """Base pad: 30x30x30 box (27000 mm^3). Groove sketch: a small
+        rectangle offset from the Y-axis on XZ_Plane, revolved 360 deg
+        around Y — cuts a ring-shaped channel out of the box. Exact
+        removed volume isn't hand-derivable here (the groove only
+        partially overlaps the box's footprint), so this asserts the
+        real, non-hypothetical property: some material was removed, the
+        result is a valid solid, and it's a genuine PartDesign::Groove
+        (not silently falling back to some other feature type)."""
+        doc_name = clean_document
+        send_command("execute_python_sync", {"code": """
+import Part, Sketcher
+doc = FreeCAD.ActiveDocument
+body = doc.addObject('PartDesign::Body', 'Body')
+
+base_sketch = doc.addObject('Sketcher::SketchObject', 'GrooveBaseSketch')
+body.addObject(base_sketch)
+base_sketch.AttachmentSupport = [(doc.getObject('XY_Plane'), '')]
+base_sketch.MapMode = 'FlatFace'
+base_sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(-15,-15,0), FreeCAD.Vector(15,-15,0)))
+base_sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(15,-15,0), FreeCAD.Vector(15,15,0)))
+base_sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(15,15,0), FreeCAD.Vector(-15,15,0)))
+base_sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(-15,15,0), FreeCAD.Vector(-15,-15,0)))
+base_sketch.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+base_sketch.addConstraint(Sketcher.Constraint('Coincident', 1, 2, 2, 1))
+base_sketch.addConstraint(Sketcher.Constraint('Coincident', 2, 2, 3, 1))
+base_sketch.addConstraint(Sketcher.Constraint('Coincident', 3, 2, 0, 1))
+doc.recompute()
+pad = body.newObject('PartDesign::Pad', 'BasePad')
+pad.Profile = base_sketch
+pad.Length = 30
+doc.recompute()
+
+groove_sketch = doc.addObject('Sketcher::SketchObject', 'GrooveSk')
+body.addObject(groove_sketch)
+groove_sketch.AttachmentSupport = [(doc.getObject('XZ_Plane'), '')]
+groove_sketch.MapMode = 'FlatFace'
+groove_sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(5,10,0), FreeCAD.Vector(10,10,0)))
+groove_sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(10,10,0), FreeCAD.Vector(10,15,0)))
+groove_sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(10,15,0), FreeCAD.Vector(5,15,0)))
+groove_sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(5,15,0), FreeCAD.Vector(5,10,0)))
+groove_sketch.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+groove_sketch.addConstraint(Sketcher.Constraint('Coincident', 1, 2, 2, 1))
+groove_sketch.addConstraint(Sketcher.Constraint('Coincident', 2, 2, 3, 1))
+groove_sketch.addConstraint(Sketcher.Constraint('Coincident', 3, 2, 0, 1))
+doc.recompute()
+result = None
+"""})
+        result = send_command("partdesign_operations", {
+            "operation": "groove", "sketch_name": "GrooveSk", "axis": "y", "angle": 360,
+        })
+        assert_op_succeeded(result, "groove")
+        props = get_shape_props(doc_name, "Groove")
+        assert props is not None
+        assert props["is_valid"]
+        assert 0 < props["volume"] < 27000.0
+        type_id = send_command("execute_python_sync", {
+            "code": "FreeCAD.ActiveDocument.getObject('Groove').TypeId"
+        })
+        assert "PartDesign::Groove" in _text(type_id)
+
+    def test_groove_z_axis_rejected(self, clean_document):
+        """Same unconditional N_Axis rejection as revolution's Body path —
+        groove.py shares the identical validation."""
+        send_command("execute_python_sync", {"code": """
+import Part, Sketcher
+doc = FreeCAD.ActiveDocument
+body = doc.addObject('PartDesign::Body', 'Body')
+sketch = doc.addObject('Sketcher::SketchObject', 'GrooveZSketch')
+body.addObject(sketch)
+sketch.AttachmentSupport = [(doc.getObject('XZ_Plane'), '')]
+sketch.MapMode = 'FlatFace'
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(5,0,0), FreeCAD.Vector(10,0,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(10,0,0), FreeCAD.Vector(10,5,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(10,5,0), FreeCAD.Vector(5,5,0)))
+sketch.addGeometry(Part.LineSegment(FreeCAD.Vector(5,5,0), FreeCAD.Vector(5,0,0)))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 1, 2, 2, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 2, 2, 3, 1))
+sketch.addConstraint(Sketcher.Constraint('Coincident', 3, 2, 0, 1))
+doc.recompute()
+result = None
+"""})
+        result = send_command("partdesign_operations", {
+            "operation": "groove", "sketch_name": "GrooveZSketch", "axis": "z", "angle": 360,
+        })
+        text = _text(result)
+        assert "n_axis" in text.lower() or "own plane" in text.lower(), text[:300]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Loft / Sweep (Part::Loft / Part::Sweep — no PartDesign Body
+# needed, unlike additive_pipe/subtractive_loft/subtractive_sweep below)
+# ---------------------------------------------------------------------------
+
+class TestLoft:
+    def test_loft_two_circles_produces_frustum(self, clean_document):
+        """A circle-to-circle loft (no Body) between R=10 at z=0 and R=5
+        at z=20 is a cone frustum: V = (pi*h/3)*(r1^2+r1*r2+r2^2) =
+        (pi*20/3)*(100+50+25) = 3665.19 mm^3. Confirmed empirically
+        against this exact FreeCAD build. Uses a direct Placement on the
+        second sketch rather than AttachmentSupport+AttachmentOffset —
+        confirmed live that combination silently fails to actually shift
+        the sketch in Z when both sketches attach to the SAME datum
+        plane object (both ended up coincident at z=0)."""
+        doc_name = clean_document
+        send_command("execute_python_sync", {"code": """
+import Part
+doc = FreeCAD.ActiveDocument
+s1 = doc.addObject('Sketcher::SketchObject', 'LoftS1')
+s1.addGeometry(Part.Circle(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1), 10))
+doc.recompute()
+s2 = doc.addObject('Sketcher::SketchObject', 'LoftS2')
+s2.Placement = FreeCAD.Placement(FreeCAD.Vector(0,0,20), FreeCAD.Rotation())
+s2.addGeometry(Part.Circle(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1), 5))
+doc.recompute()
+result = None
+"""})
+        result = send_command("partdesign_operations", {
+            "operation": "loft", "sketches": ["LoftS1", "LoftS2"],
+        })
+        assert_op_succeeded(result, "loft")
+        props = get_shape_props(doc_name, "Loft")
+        assert props is not None
+        assert props["is_valid"]
+        assert_volume_close(props["volume"], 3665.19, op_label="loft frustum")
+
+    def test_loft_requires_two_sketches(self, clean_document):
+        result = send_command("partdesign_operations", {
+            "operation": "loft", "sketches": ["OnlyOne"],
+        })
+        text = _text(result)
+        assert "at least 2 sketches" in text.lower(), text[:300]
+
+
+class TestSweep:
+    def test_sweep_circle_along_straight_line_produces_cylinder(self, clean_document):
+        """R=3 circle swept 30mm along a straight line: V = pi*3^2*30 =
+        848.23 mm^3. Confirmed empirically that Part::Sweep (Frenet=True
+        by default, unset by this handler) produces a NULL shape when
+        Sections/Spine reference Sketcher::SketchObject sketches directly
+        for a perfectly straight, axis-aligned spine (a Frenet-frame
+        degenerate case: an unbent line has no well-defined normal to
+        build a frame from) — same null-shape result whether Frenet is
+        left at its True default or explicitly set False, and whether
+        Spine is a bare object or an explicit (obj, ['Edge1']) tuple, so
+        this isn't a handler bug, it's a spine-representation quirk of
+        this exact geometry. Using plain Part::Feature objects (a Wire
+        Shape assigned directly, no Sketcher involved) for BOTH profile
+        and path sidesteps it entirely and produces a correct, non-null
+        cylinder — confirmed via the real MCP handler, not just raw OCCT
+        calls."""
+        doc_name = clean_document
+        send_command("execute_python_sync", {"code": """
+import Part
+doc = FreeCAD.ActiveDocument
+circ = Part.Circle(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1), 3)
+prof = doc.addObject('Part::Feature', 'SweepProfile')
+prof.Shape = Part.Wire([circ.toShape()])
+line_shape = Part.LineSegment(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,30)).toShape()
+path = doc.addObject('Part::Feature', 'SweepPath')
+path.Shape = Part.Wire([line_shape])
+doc.recompute()
+result = None
+"""})
+        result = send_command("partdesign_operations", {
+            "operation": "sweep", "profile_sketch": "SweepProfile", "path_sketch": "SweepPath",
+        })
+        assert_op_succeeded(result, "sweep")
+        props = get_shape_props(doc_name, "Sweep")
+        assert props is not None
+        assert props["is_valid"]
+        assert_volume_close(props["volume"], 848.23, op_label="swept cylinder")
+
+    def test_sweep_missing_profile_sketch(self, clean_document):
+        result = send_command("partdesign_operations", {
+            "operation": "sweep", "profile_sketch": "Ghost", "path_sketch": "AlsoGhost",
+        })
+        text = _text(result)
+        assert "profile sketch not found" in text.lower(), text[:300]
+
+
+# ---------------------------------------------------------------------------
+# Tests: Additive pipe / Subtractive sweep (PartDesign — need a Body;
+# both use the same bent-path recipe as TestSweep's straight-line finding
+# implies: a straight spine hits the same Frenet degeneracy here too, so
+# both fixtures use a 2-segment bent path instead)
+# ---------------------------------------------------------------------------
+
+class TestAdditivePipe:
+    def test_additive_pipe_bent_path_real_geometry(self, clean_document):
+        doc_name = clean_document
+        send_command("execute_python_sync", {"code": """
+import Part, Sketcher
+doc = FreeCAD.ActiveDocument
+body = doc.addObject('PartDesign::Body', 'Body')
+
+prof = doc.addObject('Sketcher::SketchObject', 'PipeProfile')
+body.addObject(prof)
+prof.AttachmentSupport = [(doc.getObject('XY_Plane'), '')]
+prof.MapMode = 'FlatFace'
+prof.addGeometry(Part.Circle(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1), 3))
+doc.recompute()
+
+path = doc.addObject('Sketcher::SketchObject', 'PipePath')
+body.addObject(path)
+path.AttachmentSupport = [(doc.getObject('YZ_Plane'), '')]
+path.MapMode = 'FlatFace'
+path.addGeometry(Part.LineSegment(FreeCAD.Vector(0,0,0), FreeCAD.Vector(10,10,0)))
+path.addGeometry(Part.LineSegment(FreeCAD.Vector(10,10,0), FreeCAD.Vector(0,20,0)))
+path.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+doc.recompute()
+result = None
+"""})
+        result = send_command("partdesign_operations", {
+            "operation": "additive_pipe", "profile_sketch": "PipeProfile", "path_sketch": "PipePath",
+        })
+        assert_op_succeeded(result, "additive_pipe")
+        props = get_shape_props(doc_name, "AdditivePipe")
+        assert props is not None
+        assert props["is_valid"]
+        assert props["volume"] > 0
+
+    def test_additive_pipe_missing_path_sketch(self, clean_document):
+        send_command("execute_python_sync", {"code": """
+import Part
+doc = FreeCAD.ActiveDocument
+body = doc.addObject('PartDesign::Body', 'Body')
+prof = doc.addObject('Sketcher::SketchObject', 'LonelyProfile')
+body.addObject(prof)
+prof.addGeometry(Part.Circle(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1), 3))
+doc.recompute()
+result = None
+"""})
+        result = send_command("partdesign_operations", {
+            "operation": "additive_pipe", "profile_sketch": "LonelyProfile", "path_sketch": "Ghost",
+        })
+        text = _text(result)
+        assert "path sketch not found" in text.lower(), text[:300]
+
+
+class TestSubtractiveSweep:
+    def test_subtractive_sweep_bent_path_real_geometry(self, clean_document):
+        """Base pad: 40x40x20 box (32000 mm^3). A small circular channel
+        swept along a bent path near one edge removes a modest, real
+        volume — assert strictly less than the unfilleted pad, not an
+        exact hand-derived number (the bent-path sweep's exact swept
+        volume isn't simple to hand-calculate)."""
+        doc_name = clean_document
+        send_command("execute_python_sync", {"code": """
+import Part, Sketcher
+doc = FreeCAD.ActiveDocument
+body = doc.addObject('PartDesign::Body', 'Body')
+
+base_sk = doc.addObject('Sketcher::SketchObject', 'SSBaseSk')
+body.addObject(base_sk)
+base_sk.AttachmentSupport = [(doc.getObject('XY_Plane'), '')]
+base_sk.MapMode = 'FlatFace'
+base_sk.addGeometry(Part.LineSegment(FreeCAD.Vector(-20,-20,0), FreeCAD.Vector(20,-20,0)))
+base_sk.addGeometry(Part.LineSegment(FreeCAD.Vector(20,-20,0), FreeCAD.Vector(20,20,0)))
+base_sk.addGeometry(Part.LineSegment(FreeCAD.Vector(20,20,0), FreeCAD.Vector(-20,20,0)))
+base_sk.addGeometry(Part.LineSegment(FreeCAD.Vector(-20,20,0), FreeCAD.Vector(-20,-20,0)))
+base_sk.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+base_sk.addConstraint(Sketcher.Constraint('Coincident', 1, 2, 2, 1))
+base_sk.addConstraint(Sketcher.Constraint('Coincident', 2, 2, 3, 1))
+base_sk.addConstraint(Sketcher.Constraint('Coincident', 3, 2, 0, 1))
+doc.recompute()
+pad = body.newObject('PartDesign::Pad', 'SSBasePad')
+pad.Profile = base_sk
+pad.Length = 20
+doc.recompute()
+
+prof = doc.addObject('Sketcher::SketchObject', 'SSProfile')
+body.addObject(prof)
+prof.AttachmentSupport = [(doc.getObject('XY_Plane'), '')]
+prof.MapMode = 'FlatFace'
+prof.addGeometry(Part.Circle(FreeCAD.Vector(-15,0,0), FreeCAD.Vector(0,0,1), 2))
+doc.recompute()
+
+path = doc.addObject('Sketcher::SketchObject', 'SSPath')
+body.addObject(path)
+path.AttachmentSupport = [(doc.getObject('YZ_Plane'), '')]
+path.MapMode = 'FlatFace'
+path.addGeometry(Part.LineSegment(FreeCAD.Vector(-15,0,0), FreeCAD.Vector(-10,10,0)))
+path.addGeometry(Part.LineSegment(FreeCAD.Vector(-10,10,0), FreeCAD.Vector(-15,20,0)))
+path.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+doc.recompute()
+result = None
+"""})
+        result = send_command("partdesign_operations", {
+            "operation": "subtractive_sweep", "profile_sketch": "SSProfile", "path_sketch": "SSPath",
+        })
+        assert_op_succeeded(result, "subtractive_sweep")
+        props = get_shape_props(doc_name, "SubtractivePipe")
+        assert props is not None
+        assert props["is_valid"]
+        assert 0 < props["volume"] < 32000.0
+
+
+# ---------------------------------------------------------------------------
+# Tests: Subtractive loft — regression pin, not a fix. Confirmed live,
+# across multiple geometry variants (circular sections, rectangular
+# sections, sections flush with the pad's boundary faces, sections
+# protruding beyond them), that PartDesign::SubtractiveLoft consistently
+# fails to compute (State=Invalid, null Shape) via BOTH the real MCP
+# handler and a hand-built replica using the identical FreeCAD API calls
+# the handler itself uses. Whatever is wrong here is either a genuine
+# upstream FreeCAD limitation or something about this operation's
+# geometry requirements this investigation didn't uncover — not
+# something specific to this handler's own code (the manual replica
+# fails identically). Flagged separately for deeper investigation rather
+# than continuing to guess at geometry variants.
+# ---------------------------------------------------------------------------
+
+class TestSubtractiveLoft:
+    def test_subtractive_loft_currently_fails_to_compute(self, clean_document):
+        doc_name = clean_document
+        send_command("execute_python_sync", {"code": """
+import Part, Sketcher
+doc = FreeCAD.ActiveDocument
+body = doc.addObject('PartDesign::Body', 'Body')
+base_sk = doc.addObject('Sketcher::SketchObject', 'SLBaseSk')
+body.addObject(base_sk)
+base_sk.AttachmentSupport = [(doc.getObject('XY_Plane'), '')]
+base_sk.MapMode = 'FlatFace'
+base_sk.addGeometry(Part.LineSegment(FreeCAD.Vector(-20,-20,0), FreeCAD.Vector(20,-20,0)))
+base_sk.addGeometry(Part.LineSegment(FreeCAD.Vector(20,-20,0), FreeCAD.Vector(20,20,0)))
+base_sk.addGeometry(Part.LineSegment(FreeCAD.Vector(20,20,0), FreeCAD.Vector(-20,20,0)))
+base_sk.addGeometry(Part.LineSegment(FreeCAD.Vector(-20,20,0), FreeCAD.Vector(-20,-20,0)))
+base_sk.addConstraint(Sketcher.Constraint('Coincident', 0, 2, 1, 1))
+base_sk.addConstraint(Sketcher.Constraint('Coincident', 1, 2, 2, 1))
+base_sk.addConstraint(Sketcher.Constraint('Coincident', 2, 2, 3, 1))
+base_sk.addConstraint(Sketcher.Constraint('Coincident', 3, 2, 0, 1))
+doc.recompute()
+pad = body.newObject('PartDesign::Pad', 'SLBasePad')
+pad.Profile = base_sk
+pad.Length = 20
+doc.recompute()
+
+s1 = doc.addObject('Sketcher::SketchObject', 'SLS1')
+body.addObject(s1)
+s1.AttachmentSupport = [(doc.getObject('XY_Plane'), '')]
+s1.MapMode = 'FlatFace'
+s1.addGeometry(Part.Circle(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1), 8))
+doc.recompute()
+
+s2 = doc.addObject('Sketcher::SketchObject', 'SLS2')
+body.addObject(s2)
+s2.AttachmentSupport = [(pad, 'Face6')]
+s2.MapMode = 'FlatFace'
+s2.addGeometry(Part.Circle(FreeCAD.Vector(0,0,0), FreeCAD.Vector(0,0,1), 4))
+doc.recompute()
+result = None
+"""})
+        result = send_command("partdesign_operations", {
+            "operation": "subtractive_loft", "sketches": ["SLS1", "SLS2"],
+        })
+        text = _text(result)
+        assert "failed to compute" in text and "Invalid" in text, (
+            "If this assertion fails, subtractive_loft may now be working "
+            f"— investigate and replace this pin with a real test. Got: {text[:300]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: Datum line / point (auto-creates a Body if none exists) /
+# datum_from_face (shortcut over create_datum_plane)
+# ---------------------------------------------------------------------------
+
+class TestDatumLinePoint:
+    def test_datum_line_auto_creates_body(self, clean_document):
+        result = send_command("partdesign_operations", {"operation": "datum_line"})
+        text = _text(result)
+        assert "Created datum line: DatumLine" in text, text[:300]
+        type_id = send_command("execute_python_sync", {
+            "code": "FreeCAD.ActiveDocument.getObject('DatumLine').TypeId"
+        })
+        assert "PartDesign::Line" in _text(type_id)
+
+    def test_datum_point_auto_creates_body(self, clean_document):
+        result = send_command("partdesign_operations", {"operation": "datum_point"})
+        text = _text(result)
+        assert "Created datum point: DatumPoint" in text, text[:300]
+        type_id = send_command("execute_python_sync", {
+            "code": "FreeCAD.ActiveDocument.getObject('DatumPoint').TypeId"
+        })
+        assert "PartDesign::Point" in _text(type_id)
+
+    def test_datum_point_with_offset(self, clean_document):
+        result = send_command("partdesign_operations", {
+            "operation": "datum_point", "offset_x": 5, "offset_y": 10, "offset_z": 15,
+        })
+        text = _text(result)
+        assert "Created datum point" in text, text[:300]
+
+
+class TestDatumFromFace:
+    def test_datum_from_face_on_top_face(self, body_with_pad):
+        result = send_command("partdesign_operations", {
+            "operation": "datum_from_face", "object_name": "Pad", "face_index": 6,
+        })
+        text = _text(result)
+        assert "Created datum plane: Datum_Face6" in text, text[:300]
+        assert "Face centroid:" in text and "Face normal:" in text, text[:300]
+
+    def test_datum_from_face_out_of_range(self, body_with_pad):
+        result = send_command("partdesign_operations", {
+            "operation": "datum_from_face", "object_name": "Pad", "face_index": 99,
+        })
+        text = _text(result)
+        assert "out of range" in text.lower(), text[:300]
+
+
+# ---------------------------------------------------------------------------
 # Tests: Unknown operation
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_partdesign_ops.py
+++ b/tests/integration/test_partdesign_ops.py
@@ -1079,22 +1079,23 @@ result = None
 
 
 # ---------------------------------------------------------------------------
-# Tests: Subtractive loft — regression pin, not a fix. Confirmed live,
-# across multiple geometry variants (circular sections, rectangular
-# sections, sections flush with the pad's boundary faces, sections
-# protruding beyond them), that PartDesign::SubtractiveLoft consistently
-# fails to compute (State=Invalid, null Shape) via BOTH the real MCP
-# handler and a hand-built replica using the identical FreeCAD API calls
-# the handler itself uses. Whatever is wrong here is either a genuine
-# upstream FreeCAD limitation or something about this operation's
-# geometry requirements this investigation didn't uncover — not
-# something specific to this handler's own code (the manual replica
-# fails identically). Flagged separately for deeper investigation rather
-# than continuing to guess at geometry variants.
+# Tests: Subtractive loft — was a regression pin (State=Invalid, null
+# Shape, reproduced across every geometry variant tried, both via the real
+# handler and a hand-built replica using identical FreeCAD API calls).
+# Root cause found 2026-08-21: PartDesign::SubtractiveLoft (and its
+# additive sibling PartDesign::AdditiveLoft — confirmed the SAME failure
+# reproduces there too, standalone, with no subtraction involved at all,
+# proving this was never subtraction-specific) has its own required
+# Profile property distinct from Sections, matching every other PartDesign
+# additive/subtractive feature's convention (Pad, Pocket, Revolution, ...
+# all set .Profile). The handler used to model this after the standalone
+# Part::Loft (which has no Profile property, only Sections) and put every
+# sketch into Sections with Profile left unset — fixed to set
+# loft.Profile = sketches[0] and loft.Sections = sketches[1:].
 # ---------------------------------------------------------------------------
 
 class TestSubtractiveLoft:
-    def test_subtractive_loft_currently_fails_to_compute(self, clean_document):
+    def test_subtractive_loft_real_hollow_volume(self, clean_document):
         doc_name = clean_document
         send_command("execute_python_sync", {"code": """
 import Part, Sketcher
@@ -1136,11 +1137,16 @@ result = None
         result = send_command("partdesign_operations", {
             "operation": "subtractive_loft", "sketches": ["SLS1", "SLS2"],
         })
+        assert_op_succeeded(result, "subtractive_loft")
         text = _text(result)
-        assert "failed to compute" in text and "Invalid" in text, (
-            "If this assertion fails, subtractive_loft may now be working "
-            f"— investigate and replace this pin with a real test. Got: {text[:300]}"
-        )
+        assert "Created subtractive loft" in text, text[:300]
+
+        # Base pad: 40x40x20 box = 32000 mm^3. Tapered circular channel
+        # (R=8 at bottom to R=4 at top) removes a real, non-trivial volume.
+        props = get_shape_props(doc_name, "SubtractiveLoft")
+        assert props is not None
+        assert props["is_valid"]
+        assert 0 < props["volume"] < 32000.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_view_ops.py
+++ b/tests/integration/test_view_ops.py
@@ -8,12 +8,35 @@ the queue serialization and Qt-task drain can only be exercised end-to-
 end. Unit tests with mocks cover the handler logic in test_document_ops.py;
 this file complements them with a real-FreeCAD round-trip.
 
+Also covers: delete_object, undo, redo, recompute (real headless-testable
+behavior — pure App-layer, no FreeCADGui touch); select_object,
+clear_selection, get_selection (success-but-silent-no-op headless —
+UniversalSelector's own methods check `if FreeCADGui:` and no-op when it's
+None, so these return a success string without any real 3D-view effect;
+still worth testing the returned string and the not-found error path);
+save_document (via view_control, dispatches to document_ops).
+
 Not covered here:
   * Clip planes (add_clip_plane / remove_clip_plane) — they touch Coin3D
     via pivy and we have no headless way to verify the visual effect.
+    (add_clip_plane/remove_clip_plane do have a clean, deliberate headless
+    guard — "Clip plane not available in headless mode" — rather than an
+    exception, unlike the 8 ops below, but still produce no observable
+    visual effect to assert on here.)
   * Screenshot — covered by test_view_ops_screenshot.py at the unit level
     (the macOS subprocess path is the gnarly part and doesn't benefit
     from headless integration coverage).
+  * set_view, fit_all, zoom_in, zoom_out, hide_object, show_object,
+    activate_workbench, get_report_view — all eight read FreeCADGui
+    directly (FreeCADGui.ActiveDocument, .Selection, .activateWorkbench,
+    .getMainWindow) with no headless guard, so every one of them raises
+    an AttributeError-derived string headless every time, regardless of
+    document/object state. The only legitimate integration assertion for
+    these would be "returns an error string, doesn't crash the socket" —
+    a much thinner test than the real-behavior ones above, and one that
+    can't observe whether the *intended* GUI-mode behavior still works.
+    Deliberately out of scope for this tier (candidates for a Phase 3
+    GUI-mode-only suite if ever wanted).
 """
 
 import json
@@ -212,3 +235,176 @@ class TestInsertShape:
         text = _text(result)
         assert "not found" in text.lower(), \
             f"Expected object-not-found error: {text[:300]}"
+
+
+# ---------------------------------------------------------------------------
+# delete_object / undo / redo / recompute — real, headless-testable
+# behavior, pure App layer.
+# ---------------------------------------------------------------------------
+
+class TestDeleteObject:
+    def test_delete_object_removes_it(self, clean_document):
+        doc_name = clean_document
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "ToDelete",
+        })
+        result = send_command("view_control", {
+            "operation": "delete_object", "object_name": "ToDelete",
+        })
+        text = _text(result)
+        assert "deleted" in text.lower(), text[:300]
+
+        check = send_command("execute_python_sync", {
+            "code": f"print(FreeCAD.getDocument({doc_name!r}).getObject('ToDelete') is None)\nresult = None\n"
+        })
+        assert _text(check).strip().endswith("True"), _text(check)[:300]
+
+    def test_delete_object_not_found(self, clean_document):
+        result = send_command("view_control", {
+            "operation": "delete_object", "object_name": "Ghost",
+        })
+        text = _text(result)
+        assert "not found" in text.lower(), text[:300]
+
+
+class TestUndoRedo:
+    """undo/redo currently do NOT revert anything created via any MCP
+    tool. Confirmed live and systemically: `grep -rn "openTransaction"
+    AICopilot/` returns zero matches anywhere in this codebase.
+    doc.UndoMode=1 alone does not auto-wrap arbitrary doc.addObject()
+    calls in an undo transaction the way GUI Command execution normally
+    does — FreeCAD's doc.UndoCount stays 0 after part_operations creates
+    a box (confirmed live), so doc.undo() has nothing to revert. This is
+    a real, systemic gap (every mutating handler across every workbench
+    would need doc.openTransaction()/commitTransaction() pairing to fix),
+    well beyond this test file's scope — flagged separately. These tests
+    pin the actual current (non-)behavior rather than assert the
+    documented intent, so a future fix is visible as these tests
+    starting to fail in a way that should prompt updating them, not
+    reverting the fix."""
+
+    def test_undo_does_not_currently_revert_mcp_created_objects(self, clean_document):
+        doc_name = clean_document
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "UndoBox",
+        })
+        result = send_command("view_control", {"operation": "undo"})
+        text = _text(result)
+        assert "undo" in text.lower(), text[:300]
+
+        check = send_command("execute_python_sync", {
+            "code": f"print(FreeCAD.getDocument({doc_name!r}).getObject('UndoBox') is None)\nresult = None\n"
+        })
+        assert _text(check).strip().endswith("False"), (
+            "If this now says True, undo started actually reverting MCP-created "
+            f"objects — investigate before assuming it's just this test being "
+            f"stale. Got: {_text(check)[:300]}"
+        )
+
+    def test_undo_on_document_with_no_transactions_reports_completed_not_error(self, clean_document):
+        """undo() on a document with nothing to undo doesn't error —
+        FreeCAD's Document.undo() is a silent no-op with UndoCount==0,
+        and the handler doesn't distinguish that from a real undo."""
+        result = send_command("view_control", {"operation": "undo"})
+        text = _text(result)
+        assert "Undo completed" in text, text[:300]
+
+    def test_redo_on_document_with_no_transactions_reports_completed_not_error(self, clean_document):
+        result = send_command("view_control", {"operation": "redo"})
+        text = _text(result)
+        assert "Redo completed" in text, text[:300]
+
+
+class TestRecompute:
+    def test_recompute_whole_document(self, clean_document):
+        result = send_command("view_control", {"operation": "recompute"})
+        text = _text(result)
+        assert "Recomputed document" in text, text[:300]
+
+    def test_recompute_single_object(self, clean_document):
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "RecBox",
+        })
+        result = send_command("view_control", {
+            "operation": "recompute", "object_name": "RecBox",
+        })
+        text = _text(result)
+        assert "Recomputed 'RecBox'" in text, text[:300]
+
+    def test_recompute_object_not_found(self, clean_document):
+        result = send_command("view_control", {
+            "operation": "recompute", "object_name": "Ghost",
+        })
+        text = _text(result)
+        assert "not found" in text.lower(), text[:300]
+
+
+# ---------------------------------------------------------------------------
+# select_object / clear_selection / get_selection — headless these are
+# real no-ops (UniversalSelector guards on `if FreeCADGui:`), but the
+# returned strings and not-found error paths are still real behavior
+# worth pinning.
+# ---------------------------------------------------------------------------
+
+class TestSelectionOpsHeadlessNoOp:
+    def test_select_object_success_message(self, clean_document):
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "SelBox",
+        })
+        result = send_command("view_control", {
+            "operation": "select_object", "object_name": "SelBox",
+        })
+        text = _text(result)
+        assert "Selected object 'SelBox'" in text, text[:300]
+
+    def test_select_object_not_found(self, clean_document):
+        result = send_command("view_control", {
+            "operation": "select_object", "object_name": "Ghost",
+        })
+        text = _text(result)
+        assert "not found" in text.lower(), text[:300]
+
+    def test_clear_selection(self, clean_document):
+        result = send_command("view_control", {"operation": "clear_selection"})
+        text = _text(result)
+        assert "Selection cleared" in text, text[:300]
+
+    def test_get_selection_empty_headless(self, clean_document):
+        """select_object is itself a headless no-op (no real FreeCADGui.
+        Selection to add to), so get_selection can only ever observe an
+        empty selection in this tier — that's the real, correct behavior
+        to pin, not a gap in this test."""
+        send_command("part_operations", {
+            "operation": "box", "length": 5, "width": 5, "height": 5, "name": "SelBox2",
+        })
+        send_command("view_control", {
+            "operation": "select_object", "object_name": "SelBox2",
+        })
+        result = send_command("view_control", {"operation": "get_selection"})
+        text = _text(result)
+        assert "No objects selected" in text, text[:300]
+
+
+# ---------------------------------------------------------------------------
+# save_document (view_control -> document_ops.save_document)
+# ---------------------------------------------------------------------------
+
+class TestSaveDocument:
+    def test_save_document_to_explicit_path(self, clean_document):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = f"{tmp_dir}/saved_doc.FCStd"
+            result = send_command("view_control", {
+                "operation": "save_document", "filename": path,
+            })
+            text = _text(result)
+            assert "Document saved as" in text, text[:300]
+            import os
+            assert os.path.isfile(path), f"expected file at {path}"
+
+    def test_save_document_rejects_path_outside_allowed_dirs(self, clean_document):
+        result = send_command("view_control", {
+            "operation": "save_document", "filename": "/etc/definitely_not_allowed.FCStd",
+        })
+        text = _text(result)
+        assert "outside allowed directories" in text, text[:300]

--- a/tests/unit/_freecad_mocks.py
+++ b/tests/unit/_freecad_mocks.py
@@ -697,6 +697,14 @@ def make_assembly(name="Assembly", group=None):
     obj.Type = "Assembly"
     obj.Placement = _Placement()
     obj.Group = list(group) if group else []
+    # list_joints reads the assembly's Assembly::JointGroup child (found by
+    # scanning OutList) rather than the .Joints property, since .Joints
+    # never includes GroundedJoint objects (confirmed live 2026-08-21,
+    # fixed same day) -- default to no JointGroup present (list_joints'
+    # "has no joints" path); tests needing joints/groundings should mock
+    # a JointGroup-typed object into OutList with the desired .Group
+    # contents, matching the real Assembly::JointGroup shape.
+    obj.OutList = []
     obj.isDerivedFrom = MagicMock(
         side_effect=lambda t: t == "Assembly::AssemblyObject"
     )

--- a/tests/unit/test_assembly_ops.py
+++ b/tests/unit/test_assembly_ops.py
@@ -49,6 +49,7 @@ def _make_joint_group(name="Joints"):
     mirroring make_assembly's newObject side effect."""
     jg = MagicMock()
     jg.Name = name
+    jg.TypeId = "Assembly::JointGroup"
     jg.Group = []
 
     def _new_object(type_id, obj_name=None):
@@ -59,6 +60,19 @@ def _make_joint_group(name="Joints"):
         return obj
 
     jg.newObject = MagicMock(side_effect=_new_object)
+    return jg
+
+
+def _set_joints(assembly, joints):
+    """Wire a mock Assembly::JointGroup containing `joints` into
+    assembly.OutList -- list_joints() finds the group by scanning OutList
+    for TypeId=="Assembly::JointGroup" and reads its .Group, not
+    assembly.Joints (which never includes GroundedJoint objects; fixed
+    2026-08-21). Mirrors the shape create_joint/ground_part's real
+    UtilsAssembly.getJointGroup(assembly) call produces."""
+    jg = _make_joint_group()
+    jg.Group = list(joints)
+    assembly.OutList = [jg]
     return jg
 
 
@@ -1076,7 +1090,7 @@ class TestListJoints(unittest.TestCase):
 
     def test_empty_joints(self):
         assembly = make_assembly("Asm")
-        assembly.Joints = []
+        _set_joints(assembly, [])
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
         result = self.handler.list_joints({})
@@ -1096,7 +1110,7 @@ class TestListJoints(unittest.TestCase):
         del joint.ObjectToGround
 
         assembly = make_assembly("Asm")
-        assembly.Joints = [joint]
+        _set_joints(assembly, [joint])
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -1112,7 +1126,7 @@ class TestListJoints(unittest.TestCase):
         ground.ObjectToGround = box
 
         assembly = make_assembly("Asm")
-        assembly.Joints = [ground]
+        _set_joints(assembly, [ground])
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -1129,7 +1143,7 @@ class TestListJoints(unittest.TestCase):
         del joint.ObjectToGround
 
         assembly = make_assembly("Asm")
-        assembly.Joints = [joint]
+        _set_joints(assembly, [joint])
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -1150,7 +1164,7 @@ class TestListJoints(unittest.TestCase):
             del j.ObjectToGround
             joints.append(j)
         assembly = make_assembly("Asm")
-        assembly.Joints = joints
+        _set_joints(assembly, joints)
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -1178,7 +1192,7 @@ class TestListJoints(unittest.TestCase):
         bad.Name = "BadJoint"
 
         assembly = make_assembly("Asm")
-        assembly.Joints = [bad, good]
+        _set_joints(assembly, [bad, good])
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -1196,7 +1210,7 @@ class TestListJoints(unittest.TestCase):
         del joint.ObjectToGround
 
         assembly = make_assembly("Asm")
-        assembly.Joints = [joint]
+        _set_joints(assembly, [joint])
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -1216,7 +1230,7 @@ class TestListJoints(unittest.TestCase):
         del joint.ObjectToGround
 
         assembly = make_assembly("Asm")
-        assembly.Joints = [joint]
+        _set_joints(assembly, [joint])
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -1238,7 +1252,7 @@ class TestListJoints(unittest.TestCase):
         joint.EnableLengthMax = False
 
         assembly = make_assembly("Asm")
-        assembly.Joints = [joint]
+        _set_joints(assembly, [joint])
         doc = make_mock_doc([assembly])
         mock_FreeCAD.ActiveDocument = doc
 
@@ -1488,7 +1502,7 @@ class TestGetPartStatus(unittest.TestCase):
         joint.Reference2 = None
         del joint.ObjectToGround
 
-        assembly.Joints = [ground, joint]
+        _set_joints(assembly, [ground, joint])
         doc = make_mock_doc([box, assembly])
         mock_FreeCAD.ActiveDocument = doc
 

--- a/tests/unit/test_cam_wrappers.py
+++ b/tests/unit/test_cam_wrappers.py
@@ -692,6 +692,78 @@ class TestCreateJob(unittest.TestCase):
         mock_Path_Main_Job.Create.assert_not_called()
 
 
+class TestSetupStock(unittest.TestCase):
+    """setup_stock's stock_type dispatch — CreateBox/CreateCylinder/
+    FromBase each set different properties on job.Stock, and an
+    unrecognized stock_type must error rather than silently leave
+    job.Stock untouched while still reporting success (confirmed live
+    2026-08-21, fixed same day: CreateCylinder wasn't implemented at all
+    despite being in the tool schema's own enum)."""
+
+    def setUp(self):
+        reset_mocks()
+        self.handler = make_handler(CAMOpsHandler)
+
+    def test_create_box_sets_dimensions(self):
+        job = make_cam_job("Job1")
+        doc = make_mock_doc([job])
+        mock_FreeCAD.ActiveDocument = doc
+        stock = MagicMock()
+        mock_Path_Main_Stock.CreateBox = MagicMock(return_value=stock)
+
+        result = self.handler.setup_stock({
+            'job_name': 'Job1', 'stock_type': 'CreateBox',
+            'length': 80, 'width': 60, 'height': 20,
+        })
+
+        mock_Path_Main_Stock.CreateBox.assert_called_once_with(job)
+        self.assertEqual(stock.Length, 80)
+        self.assertEqual(stock.Width, 60)
+        self.assertEqual(stock.Height, 20)
+        assert_success_contains(self, result, "CreateBox")
+
+    def test_create_cylinder_sets_radius_and_height(self):
+        job = make_cam_job("Job1")
+        doc = make_mock_doc([job])
+        mock_FreeCAD.ActiveDocument = doc
+        stock = MagicMock()
+        mock_Path_Main_Stock.CreateCylinder = MagicMock(return_value=stock)
+
+        result = self.handler.setup_stock({
+            'job_name': 'Job1', 'stock_type': 'CreateCylinder',
+            'radius': 30, 'height': 15,
+        })
+
+        mock_Path_Main_Stock.CreateCylinder.assert_called_once_with(job)
+        self.assertEqual(stock.Radius, 30)
+        self.assertEqual(stock.Height, 15)
+        assert_success_contains(self, result, "CreateCylinder")
+
+    def test_create_cylinder_radius_defaults_when_omitted(self):
+        job = make_cam_job("Job1")
+        doc = make_mock_doc([job])
+        mock_FreeCAD.ActiveDocument = doc
+        stock = MagicMock()
+        mock_Path_Main_Stock.CreateCylinder = MagicMock(return_value=stock)
+
+        self.handler.setup_stock({'job_name': 'Job1', 'stock_type': 'CreateCylinder'})
+
+        self.assertEqual(stock.Radius, 50)
+
+    def test_unknown_stock_type_errors_and_leaves_stock_untouched(self):
+        job = make_cam_job("Job1")
+        job.Stock = None
+        doc = make_mock_doc([job])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.setup_stock({
+            'job_name': 'Job1', 'stock_type': 'CreateCone',
+        })
+
+        assert_error_contains(self, result, "Unknown stock_type")
+        self.assertIsNone(job.Stock)
+
+
 class TestConfigureJob(unittest.TestCase):
     """configure_job's stock_type branch must be checked before other
     fields are applied, so a call combining stock_type with e.g.

--- a/tests/unit/test_cam_wrappers.py
+++ b/tests/unit/test_cam_wrappers.py
@@ -692,6 +692,58 @@ class TestCreateJob(unittest.TestCase):
         mock_Path_Main_Job.Create.assert_not_called()
 
 
+class TestConfigureJob(unittest.TestCase):
+    """configure_job's stock_type branch must be checked before other
+    fields are applied, so a call combining stock_type with e.g.
+    output_file doesn't silently apply-but-not-recompute the others (the
+    stock_type check used to run last and early-return past the recompute
+    that would otherwise finalize the already-applied changes)."""
+
+    def setUp(self):
+        reset_mocks()
+        self.handler = make_handler(CAMOpsHandler)
+
+    def test_output_file_alone_is_applied_and_recomputed(self):
+        job = make_cam_job("Job1")
+        doc = make_mock_doc([job])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.configure_job({
+            'job_name': 'Job1', 'output_file': '/tmp/out.ngc',
+        })
+
+        self.assertEqual(job.PostProcessorOutputFile, '/tmp/out.ngc')
+        assert_success_contains(self, result, "output_file")
+
+    def test_stock_type_alone_returns_setup_stock_message(self):
+        job = make_cam_job("Job1")
+        doc = make_mock_doc([job])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.configure_job({
+            'job_name': 'Job1', 'stock_type': 'CreateCylinder',
+        })
+
+        self.assertIn("setup_stock", result)
+
+    def test_stock_type_combined_with_output_file_does_not_apply_either(self):
+        """stock_type is checked first now, so a combined call rejects up
+        front rather than mutating PostProcessorOutputFile and then
+        discarding that change behind a stock_type-only message."""
+        job = make_cam_job("Job1")
+        doc = make_mock_doc([job])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.configure_job({
+            'job_name': 'Job1',
+            'stock_type': 'CreateCylinder',
+            'output_file': '/tmp/out.ngc',
+        })
+
+        self.assertIn("setup_stock", result)
+        self.assertNotEqual(job.PostProcessorOutputFile, '/tmp/out.ngc')
+
+
 class TestCreateToolShapes(unittest.TestCase):
     def setUp(self):
         reset_mocks()

--- a/tests/unit/test_execute_python_ops.py
+++ b/tests/unit/test_execute_python_ops.py
@@ -123,5 +123,85 @@ class TestExecutePython(unittest.TestCase):
         self.assertEqual(second["result"], "198")
 
 
+class TestConsoleStderrCapture(unittest.TestCase):
+    """FreeCAD's own C++ Console output (Console.PrintWarning/PrintError/
+    etc, and warnings FreeCAD emits internally as a side effect of property
+    sets/recomputes) writes via raw fprintf(stderr, ...) at the C level --
+    below Python's sys.stdout/sys.stderr, so it's invisible to run_code()'s
+    existing io.StringIO() capture (issue #49). run_code() now also
+    redirects the real OS-level stderr fd for the duration of execution.
+
+    These tests exercise that redirect directly via os.write(2, ...) --
+    the same mechanism FreeCAD's fprintf(stderr, ...) uses (a raw write to
+    the OS file descriptor, bypassing Python's sys.stderr object entirely)
+    -- rather than needing a real FreeCAD process, since the capture
+    mechanism itself doesn't care what wrote to fd 2."""
+
+    def setUp(self):
+        reset_mocks()
+        server = MagicMock()
+        server.selector = MagicMock()
+        server._run_on_gui_thread = MagicMock(side_effect=_run_on_gui_thread_headless)
+        self.handler = make_handler(ExecutePythonOpsHandler, server=server)
+
+    def _run_python(self, code):
+        response = self.handler.execute({"code": code})
+        return json.loads(response)
+
+    def test_raw_stderr_write_surfaced_in_response(self):
+        result = self._run_python("import os\nos.write(2, b'raw C-level warning\\n')")
+        self.assertIn("[FreeCAD Console]", result["result"])
+        self.assertIn("raw C-level warning", result["result"])
+
+    def test_no_stderr_output_omits_console_section(self):
+        """No stderr writes -> no '[FreeCAD Console]' noise in a plain
+        response, matching the existing "just the value" behavior."""
+        result = self._run_python("1 + 1")
+        self.assertEqual(result["result"], "2")
+        self.assertNotIn("[FreeCAD Console]", result["result"])
+
+    def test_stdout_and_console_stderr_both_present_and_ordered(self):
+        """Python print() (StringIO capture) and raw stderr (fd capture)
+        are two independent, non-overlapping channels -- both should show
+        up, stdout first (matches the existing stdout-then-result order)."""
+        code = "print('normal stdout')\nimport os\nos.write(2, b'a warning\\n')"
+        result = self._run_python(code)
+        text = result["result"]
+        self.assertIn("normal stdout", text)
+        self.assertIn("[FreeCAD Console]\na warning", text)
+        self.assertLess(text.index("normal stdout"), text.index("[FreeCAD Console]"))
+
+    def test_fd_restored_after_capture_for_next_call(self):
+        """The real stderr fd must be restored after each call -- a leak
+        or dangling redirect here would corrupt every later call's stderr
+        (including pytest's own), not just this handler's."""
+        first = self._run_python("import os\nos.write(2, b'first warning\\n')")
+        self.assertIn("first warning", first["result"])
+        # A second, independent call must only see its OWN write, not a
+        # leftover redirect from the first (would indicate the fd wasn't
+        # properly restored/closed).
+        second = self._run_python("import os\nos.write(2, b'second warning\\n')")
+        self.assertIn("second warning", second["result"])
+        self.assertNotIn("first warning", second["result"])
+
+    def test_fd_restored_after_syntax_error(self):
+        """The finally block restores the fd even on the SyntaxError early-
+        return path -- a real risk here since that path returns before the
+        normal parts-building code runs."""
+        error_result = self._run_python("def (broken")
+        self.assertIn("error", error_result)
+        # Fd must still be usable/restored for the next call.
+        after = self._run_python("import os\nos.write(2, b'after syntax error\\n')")
+        self.assertIn("after syntax error", after["result"])
+
+    def test_fd_restored_after_runtime_error(self):
+        """Same guard as the SyntaxError case, for the generic-exception
+        early-return path."""
+        error_result = self._run_python("1 / 0")
+        self.assertIn("error", error_result)
+        after = self._run_python("import os\nos.write(2, b'after runtime error\\n')")
+        self.assertIn("after runtime error", after["result"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit/test_fixture_ops.py
+++ b/tests/unit/test_fixture_ops.py
@@ -59,13 +59,19 @@ def _make_box_obj(name="Box", volume=1000.0, faces=6, edges=12, vertices=8,
         volume=volume, faces=faces, edges=edges, vertices=vertices,
         bbox=(xmax - xmin, ymax - ymin, zmax - zmin),
         is_closed=is_closed,
+        # fixture_ops.py derives is_solid from bool(shape.Solids), not a
+        # shape.isSolid() call — that method doesn't exist on real FreeCAD
+        # Part.Shape/Part.Solid objects as of weekly-2026.08.20 (confirmed
+        # live, fixed 2026-08-21). solids=1 when is_solid=True mirrors a
+        # real solid's own .Solids traversal including itself; solids=0
+        # mirrors a bare Face/open Shell's empty .Solids.
+        solids=1 if is_solid else 0,
     )
     # Override bbox mins (make_part_object sets XMin=0 by default)
     bb = obj.Shape.BoundBox
     bb.XMin, bb.XMax = xmin, xmax
     bb.YMin, bb.YMax = ymin, ymax
     bb.ZMin, bb.ZMax = zmin, zmax
-    obj.Shape.isSolid = MagicMock(return_value=is_solid)
     return obj
 
 

--- a/tests/unit/test_freecad_mcp_handler.py
+++ b/tests/unit/test_freecad_mcp_handler.py
@@ -25,6 +25,14 @@ sys.path.insert(0, AICOPILOT_DIR)
 # of each test that uses it.
 import freecad_health
 
+# Likewise grab the real PartDesignOpsHandler class now, before mock_handlers
+# replaces sys.modules["handlers"] with a plain (non-package) module of
+# MagicMocks — TestContinueSelectionDispatch needs the actual class to check
+# a resume-route method name really exists, not a MagicMock that
+# auto-vivifies any attribute you ask for.
+import tests.unit._freecad_mocks  # noqa: F401 — installs FreeCAD/Part/etc. mocks into sys.modules
+from handlers.partdesign_ops import PartDesignOpsHandler
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -1926,11 +1934,33 @@ class TestContinueSelectionDispatch:
         """Every method that calls selector.request_selection() must be
         resumable — a sixth interactive-selection method added later without
         a matching resume_methods entry would silently dead-letter its
-        continuation, same as continue_selection did before this fix."""
-        for tool_name in (
-            "fillet_edges", "chamfer_edges", "draft_faces",
-            "shell_solid", "thickness_faces",
-        ):
+        continuation, same as continue_selection did before this fix.
+
+        `server.partdesign_ops` is a MagicMock (see mock_handlers fixture),
+        so `getattr(server.partdesign_ops, tool_name)` auto-vivifies rather
+        than raising — comparing two auto-vivified attributes of the same
+        name is trivially true regardless of whether that name is a real
+        method on the actual class. That let resume_methods map
+        "thickness_faces" to a nonexistent `PartDesignOpsHandler.thickness_faces`
+        (real method is `add_thickness`) for a month undetected — every
+        continue_selection call raised AttributeError building the dict,
+        breaking fillet/chamfer/draft/shell too, not just thickness (fixed
+        2026-08-20). Assert against the REAL class's methods, not the mock,
+        so a wrong attribute name fails here instead of only in a live
+        FreeCAD session."""
+        tool_to_real_method = {
+            "fillet_edges": "fillet_edges",
+            "chamfer_edges": "chamfer_edges",
+            "draft_faces": "draft_faces",
+            "shell_solid": "shell_solid",
+            "thickness_faces": "add_thickness",
+        }
+        for tool_name, real_method_name in tool_to_real_method.items():
+            assert hasattr(PartDesignOpsHandler, real_method_name), (
+                f"resume_methods maps tool '{tool_name}' to "
+                f"PartDesignOpsHandler.{real_method_name}, which doesn't exist"
+            )
+
             server.selector.pending_operations["op_x"] = {
                 "tool": tool_name, "type": "edges", "object": "Box", "timestamp": 0.0,
             }
@@ -1939,7 +1969,7 @@ class TestContinueSelectionDispatch:
             )
             server._execute_tool_inner("continue_selection", {"operation_id": "op_x"})
             method = server._call_on_gui_thread_async.call_args[0][0]
-            assert method == getattr(server.partdesign_ops, tool_name)
+            assert method == getattr(server.partdesign_ops, real_method_name)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_mcp_protocol.py
+++ b/tests/unit/test_mcp_protocol.py
@@ -245,3 +245,87 @@ class TestExecutePythonNonJsonResponse:
         parsed = json.loads(content[0].text)
         assert "error" in parsed
         assert "non-json" in parsed["error"].lower() or "json" in parsed["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# cam_tool_controllers — omitted tool_number must reach the bridge omitted,
+# not filled in from a JSON-schema default. Regression test for the schema
+# `"default": 1` bug: a schema-respecting client (or jsonschema itself) could
+# fill in tool_number=1 before the handler's `'tool_number' in args` check
+# ever runs, making the auto-assign path dead. See freecad_mcp_server.py's
+# cam_tool_controllers tool schema and AICopilot/handlers/cam_tool_controllers.py.
+# ---------------------------------------------------------------------------
+
+
+class TestCamToolControllersSchemaHasNoDefaults:
+    """The MCP tool schemas for cam_tool_controllers/cam_tools/cam_operations
+    intentionally omit "default" on fields whose handlers do a presence
+    check (`if 'field' in args`) rather than `args.get(field, fallback)` —
+    a declared schema default gets sent explicitly by schema-respecting
+    clients, making "omitted" indistinguishable from "explicitly chose the
+    default value". Pins that this doesn't regress."""
+
+    _NO_DEFAULT_FIELDS = {
+        "cam_tool_controllers": ["tool_number", "spindle_speed", "feed_rate"],
+        "cam_tools": ["diameter"],
+        "cam_operations": ["stock_type", "post_processor"],
+    }
+
+    def test_presence_checked_fields_have_no_schema_default(self):
+        tools_by_name = {t.name: t for t in _list_tools()}
+        for tool_name, fields in self._NO_DEFAULT_FIELDS.items():
+            props = tools_by_name[tool_name].input_schema["properties"]
+            for field in fields:
+                assert "default" not in props[field], (
+                    f"{tool_name}.{field} declares a schema default; a "
+                    "schema-respecting client can send it explicitly, "
+                    "making the handler's presence check always true"
+                )
+
+
+class TestCamToolControllersToolNumberOmission:
+    def test_omitted_tool_number_reaches_bridge_omitted(self):
+        from unittest.mock import MagicMock as _MagicMock
+
+        captured_commands = []
+
+        def _fake_send_message(sock, command):
+            captured_commands.append(command)
+            return True
+
+        # See TestExecutePythonNonJsonResponse above for why the event loop
+        # is created outside the patched block.
+        loop = asyncio.new_event_loop()
+        try:
+            async def _call():
+                entry = _SERVER.get_request_handler("tools/call")
+                params = types.CallToolRequestParams(
+                    name="cam_tool_controllers",
+                    arguments={
+                        "operation": "add_tool_controller",
+                        "job_name": "Job",
+                        "tool_name": "EM6",
+                    },
+                )
+                result = await entry.handler(None, params)
+                return result.content
+
+            with patch.object(freecad_mcp_server._ctx, "resolve_target",
+                               return_value=("/tmp/fake.sock", None)), \
+                 patch.object(freecad_mcp_server.socket, "socket") as mock_socket_cls, \
+                 patch.object(freecad_mcp_server, "send_message", _fake_send_message), \
+                 patch.object(freecad_mcp_server, "receive_message",
+                               return_value=json.dumps({"result": "ok"})):
+                mock_socket_cls.return_value = _MagicMock()
+
+                loop.run_until_complete(_call())
+        finally:
+            loop.close()
+
+        assert len(captured_commands) == 1
+        sent_args = json.loads(captured_commands[0])["args"]
+        assert "tool_number" not in sent_args, (
+            "tool_number was omitted by the caller but reached the bridge "
+            "anyway -- a JSON-schema default is leaking through the MCP "
+            "dispatch layer"
+        )

--- a/tests/unit/test_partdesign_ops.py
+++ b/tests/unit/test_partdesign_ops.py
@@ -246,6 +246,27 @@ class TestFilletEdges(unittest.TestCase):
         self.assertEqual(fillet.Edges, [(1, 1.5, 1.5), (2, 1.5, 1.5), (3, 1.5, 1.5)])
         assert_success_contains(self, result, "3 edges", "1.5")
 
+    def test_explicit_edges_rejects_out_of_range_index_when_no_body(self):
+        """Out-of-range indices used to be silently dropped here (edge_list
+        built via `if 1 <= idx <= n_edges`), creating a fillet on fewer
+        edges than requested with no indication any were skipped -- the
+        Body path has no such filter at all, so it fails loudly via
+        _check_feature_state instead. Fixed 2026-08-21 to reject up front
+        here too, matching that same fail-loud contract, instead of
+        silently under-filleting."""
+        box = make_box_object("B")  # default 12 edges
+        doc = make_mock_doc([box])
+        mock_FreeCAD.ActiveDocument = doc
+
+        result = self.handler.fillet_edges({
+            'object_name': 'B', 'radius': 1.5, 'edges': [1, 99],
+        })
+
+        assert_error_contains(self, result, "99", "valid range")
+        # No object should have been created at all -- validated before
+        # doc.addObject(), not after a partial fillet already exists.
+        doc.addObject.assert_not_called()
+
     def test_explicit_edges_creates_partdesign_fillet_in_body(self):
         """Object inside a Body gets a PartDesign::Fillet."""
         box = make_box_object("B")

--- a/tests/unit/test_partdesign_ops.py
+++ b/tests/unit/test_partdesign_ops.py
@@ -1195,6 +1195,14 @@ class TestSubtractiveLoft(unittest.TestCase):
         assert_error_contains(self, result, "partdesign body")
 
     def test_creates_subtractive_loft_in_body(self):
+        """PartDesign::SubtractiveLoft has its own required Profile
+        property distinct from Sections (like every other PartDesign
+        additive/subtractive feature) -- unlike the standalone Part::Loft
+        this method used to be modeled after. Profile must get the first
+        sketch and Sections only the rest; putting every sketch
+        (including the first) into Sections with Profile left unset
+        left the feature permanently State=Invalid with a null Shape
+        (confirmed live 2026-08-21, fixed same day)."""
         s1 = make_sketch("S1")
         s2 = make_sketch("S2")
         body = make_body("Body", group=[s1, s2])
@@ -1205,8 +1213,23 @@ class TestSubtractiveLoft(unittest.TestCase):
 
         body.newObject.assert_called_with("PartDesign::SubtractiveLoft", "SubtractiveLoft")
         loft = body.newObject.return_value
-        self.assertEqual(list(loft.Sections), [s1, s2])
+        self.assertEqual(loft.Profile, s1)
+        self.assertEqual(list(loft.Sections), [s2])
         assert_success_contains(self, result, "2 profiles")
+
+    def test_three_sketches_first_is_profile_rest_are_sections(self):
+        s1 = make_sketch("S1")
+        s2 = make_sketch("S2")
+        s3 = make_sketch("S3")
+        body = make_body("Body", group=[s1, s2, s3])
+        doc = make_mock_doc([body, s1, s2, s3])
+        mock_FreeCAD.ActiveDocument = doc
+
+        self.handler.subtractive_loft({'sketches': ['S1', 'S2', 'S3']})
+
+        loft = body.newObject.return_value
+        self.assertEqual(loft.Profile, s1)
+        self.assertEqual(list(loft.Sections), [s2, s3])
 
     def test_invalid_state_errors_instead_of_false_success(self):
         s1 = make_sketch("S1")

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ wheels = [
 
 [[package]]
 name = "freecad-mcp"
-version = "7.2.0"
+version = "7.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Summary
- `execute_python()` now surfaces FreeCAD Console warnings/errors (deprecation notices, recompute warnings, etc.), not just Python `print()` output (closes #49)
- CAM: `setup_stock`'s `CreateCylinder` stock type implemented (was a silent no-op)
- PartDesign: `hole_wizard` infers `hole_type` from `operation` instead of always defaulting to `simple`
- PartDesign: `fillet`'s non-Body path now rejects out-of-range edge indices instead of silently dropping them
- PartDesign: `subtractive_loft` fixed (was permanently `State=Invalid` — missing `.Profile`)
- Assembly: `list_joints`/`get_part_status` now show groundings (were excluded from `assembly.Joints`)
- `continue_selection` dispatch fixed for all 5 interactive-selection tools (was broken for `thickness_faces`, silently dropped since 2026-07-18)
- `fixture_ops` STL export and `is_solid` detection fixed for the current FreeCAD API
- MCP schema defaults no longer mask omitted args
- Broad integration test coverage expansion: assembly, fixture, continue_selection, and other previously-uncovered tools
- Fixed a real pipe-full deadlock in the CI test harness itself (headless FreeCAD's stdout/stderr were never drained, so console progress-bar output eventually filled the OS pipe buffer and wedged the process)
- Version bump: 7.2.0 -> 7.3.0 (`pyproject.toml`, `server.json`, `AICopilot/freecad_mcp_handler.py`, `uv.lock`)

Note: this PR is from `release-v7.3.0`, not `dev` directly — the original PR (#63) hit the recurring dev/main history-divergence issue (documented in this session's project memory as a known, previously-seen pattern at v6.0.0/v7.0.0/v7.1.0). `release-v7.3.0` is `dev` rebased onto `main` in a throwaway branch; `git diff origin/dev release-v7.3.0 --stat` is empty, confirming no content changed, only the commit graph.

## Test plan
- [x] `.venv/bin/python3 -m pytest tests/unit/ -q` — 1774 passed
- [x] `.venv/bin/python3 -m pytest tests/integration/ -q -m "not real_document and not fc_tools"` — 332 passed, stable across repeated runs
- [x] CI green on both matrix slots (FreeCAD 1.1-stable, FreeCAD dev-weekly) at the version-bump commit
- [x] execute_python's Console-warning capture verified live against a real FreeCAD instance, including the exact `Midplane`/`PartDesign::Pad` deprecation-warning scenario from issue #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)